### PR TITLE
feat: add keyboard shortcuts for navigation (go back and go forward)

### DIFF
--- a/oxide-browser/src/ui.rs
+++ b/oxide-browser/src/ui.rs
@@ -912,18 +912,28 @@ impl OxideApp {
     }
 
     fn handle_keyboard_shortcuts(&mut self, ctx: &egui::Context) {
-        let (new_tab, close_tab, next_tab, prev_tab, toggle_bookmark, toggle_panel) =
-            ctx.input(|i| {
-                let cmd = i.modifiers.command;
-                (
-                    cmd && i.key_pressed(egui::Key::T),
-                    cmd && i.key_pressed(egui::Key::W),
-                    i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::Tab),
-                    i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Tab),
-                    cmd && i.key_pressed(egui::Key::D),
-                    cmd && i.key_pressed(egui::Key::B),
-                )
-            });
+        let (
+            new_tab,
+            close_tab,
+            next_tab,
+            prev_tab,
+            toggle_bookmark,
+            toggle_panel,
+            go_back,
+            go_foward,
+        ) = ctx.input(|i| {
+            let cmd = i.modifiers.command;
+            (
+                cmd && i.key_pressed(egui::Key::T),
+                cmd && i.key_pressed(egui::Key::W),
+                i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::Tab),
+                i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Tab),
+                cmd && i.key_pressed(egui::Key::D),
+                cmd && i.key_pressed(egui::Key::B),
+                i.modifiers.alt && i.key_pressed(egui::Key::ArrowLeft),
+                i.modifiers.alt && i.key_pressed(egui::Key::ArrowRight),
+            )
+        });
 
         if new_tab {
             let idx = self.create_tab();
@@ -948,6 +958,12 @@ impl OxideApp {
         }
         if toggle_panel {
             self.show_bookmarks = !self.show_bookmarks;
+        }
+        if go_back {
+            self.tabs[self.active_tab].go_back();
+        }
+        if go_foward {
+            self.tabs[self.active_tab].go_forward();
         }
     }
 

--- a/oxide-browser/src/ui.rs
+++ b/oxide-browser/src/ui.rs
@@ -920,7 +920,7 @@ impl OxideApp {
             toggle_bookmark,
             toggle_panel,
             go_back,
-            go_foward,
+            go_forward,
         ) = ctx.input(|i| {
             let cmd = i.modifiers.command;
             (
@@ -930,8 +930,10 @@ impl OxideApp {
                 i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Tab),
                 cmd && i.key_pressed(egui::Key::D),
                 cmd && i.key_pressed(egui::Key::B),
-                i.modifiers.alt && i.key_pressed(egui::Key::ArrowLeft),
-                i.modifiers.alt && i.key_pressed(egui::Key::ArrowRight),
+                i.modifiers.alt && i.key_pressed(egui::Key::ArrowLeft)&& !ctx.wants_keyboard_input(),
+                i.modifiers.alt
+                    && i.key_pressed(egui::Key::ArrowRight)
+                    && !ctx.wants_keyboard_input(),
             )
         });
 
@@ -962,7 +964,7 @@ impl OxideApp {
         if go_back {
             self.tabs[self.active_tab].go_back();
         }
-        if go_foward {
+        if go_forward {
             self.tabs[self.active_tab].go_forward();
         }
     }


### PR DESCRIPTION
Partially implements #21 

- Alt + Left Arrow: go back
- Alt + Right Arrow: go forward

These shortcuts call the existing `go_back` and `go_forward` methods on the active tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for navigation: Alt+ArrowLeft to go back and Alt+ArrowRight to go forward through page history.

* **Improvements**
  * Shortcuts won't trigger while typing in focused text inputs, preventing accidental navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->