### PR TITLE
feat(audio): format detection and HTTP codec negotiation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,7 +42,7 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 - [x] `audio_duration()` — get total duration of loaded track
 - [x] `audio_set_loop(enabled)` — loop playback toggle
 - [x] Multiple simultaneous audio channels for sound effects and background music
-- [ ] Audio format detection and codec negotiation
+- [x] Audio format detection and codec negotiation
 
 ### Video
 

--- a/oxide-browser/src/audio_format.rs
+++ b/oxide-browser/src/audio_format.rs
@@ -1,0 +1,133 @@
+//! Magic-byte sniffing and MIME mapping for supported guest audio containers.
+
+/// Unknown or not recognized as a supported Oxide audio format.
+pub const AUDIO_FORMAT_UNKNOWN: u32 = 0;
+/// WAV / RIFF WAVE.
+pub const AUDIO_FORMAT_WAV: u32 = 1;
+/// MP3 (MPEG-1/2 Audio Layer III).
+pub const AUDIO_FORMAT_MP3: u32 = 2;
+/// Ogg (Vorbis, Opus, etc.).
+pub const AUDIO_FORMAT_OGG: u32 = 3;
+/// FLAC lossless.
+pub const AUDIO_FORMAT_FLAC: u32 = 4;
+
+/// `Accept` header sent with [`super::capabilities`] URL fetches so servers can pick a codec/container.
+pub const AUDIO_HTTP_ACCEPT: &str = "audio/wav,audio/wave,audio/x-wav;q=0.9,audio/mpeg,audio/mp3;q=0.9,audio/ogg,audio/flac,audio/*;q=0.5,*/*;q=0.1";
+
+fn skip_id3_prefix(data: &[u8]) -> usize {
+    if data.len() >= 10 && data[0..3] == *b"ID3" {
+        let size = ((data[6] as usize) << 21)
+            | ((data[7] as usize) << 14)
+            | ((data[8] as usize) << 7)
+            | (data[9] as usize);
+        10 + size
+    } else {
+        0
+    }
+}
+
+fn mp3_sync_at(data: &[u8], offset: usize) -> bool {
+    if offset + 2 > data.len() {
+        return false;
+    }
+    let b0 = data[offset];
+    let b1 = data[offset + 1];
+    (b0 == 0xFF) && ((b1 & 0xE0) == 0xE0)
+}
+
+/// Inspect leading bytes (and minimal MP3 frame sync after ID3) to guess the container/codec.
+pub fn sniff_audio_format(data: &[u8]) -> u32 {
+    if data.len() < 4 {
+        return AUDIO_FORMAT_UNKNOWN;
+    }
+    if data.len() >= 12 && &data[0..4] == b"RIFF" && &data[8..12] == b"WAVE" {
+        return AUDIO_FORMAT_WAV;
+    }
+    if &data[0..4] == b"fLaC" {
+        return AUDIO_FORMAT_FLAC;
+    }
+    if &data[0..4] == b"OggS" {
+        return AUDIO_FORMAT_OGG;
+    }
+    let off = skip_id3_prefix(data);
+    if off < data.len() && mp3_sync_at(data, off) {
+        return AUDIO_FORMAT_MP3;
+    }
+    if mp3_sync_at(data, 0) {
+        return AUDIO_FORMAT_MP3;
+    }
+    AUDIO_FORMAT_UNKNOWN
+}
+
+/// Map a `Content-Type` (or similar) value to [`AUDIO_FORMAT_*`], or [`AUDIO_FORMAT_UNKNOWN`].
+pub fn mime_to_audio_format(mime: &str) -> u32 {
+    let s = mime
+        .split(';')
+        .next()
+        .unwrap_or(mime)
+        .trim()
+        .to_ascii_lowercase();
+    match s.as_str() {
+        "audio/wav" | "audio/wave" | "audio/x-wav" => AUDIO_FORMAT_WAV,
+        "audio/mpeg" | "audio/mp3" => AUDIO_FORMAT_MP3,
+        "audio/ogg" | "application/ogg" => AUDIO_FORMAT_OGG,
+        "audio/flac" | "audio/x-flac" => AUDIO_FORMAT_FLAC,
+        _ => AUDIO_FORMAT_UNKNOWN,
+    }
+}
+
+/// MIME types that usually indicate an HTML/JSON error body rather than a media stream.
+pub fn is_likely_non_audio_document(mime: &str) -> bool {
+    let s = mime
+        .split(';')
+        .next()
+        .unwrap_or(mime)
+        .trim()
+        .to_ascii_lowercase();
+    s.starts_with("text/html")
+        || s.starts_with("text/plain")
+        || s.starts_with("text/css")
+        || s == "application/json"
+        || s == "application/javascript"
+        || s.starts_with("application/xml")
+        || s.starts_with("text/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sniff_wav() {
+        let mut b = vec![0u8; 12];
+        b[0..4].copy_from_slice(b"RIFF");
+        b[8..12].copy_from_slice(b"WAVE");
+        assert_eq!(sniff_audio_format(&b), AUDIO_FORMAT_WAV);
+    }
+
+    #[test]
+    fn sniff_flac() {
+        assert_eq!(sniff_audio_format(b"fLaCxxxx"), AUDIO_FORMAT_FLAC);
+    }
+
+    #[test]
+    fn sniff_ogg() {
+        assert_eq!(sniff_audio_format(b"OggSxxxx"), AUDIO_FORMAT_OGG);
+    }
+
+    #[test]
+    fn sniff_mp3_sync() {
+        let b = [0xFF, 0xFB, 0x90, 0x00];
+        assert_eq!(sniff_audio_format(&b), AUDIO_FORMAT_MP3);
+    }
+
+    #[test]
+    fn mime_maps() {
+        assert_eq!(mime_to_audio_format("audio/mpeg"), AUDIO_FORMAT_MP3);
+        assert_eq!(
+            mime_to_audio_format("audio/ogg; codecs=vorbis"),
+            AUDIO_FORMAT_OGG
+        );
+        assert!(is_likely_non_audio_document("text/html; charset=utf-8"));
+    }
+}

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -16,8 +16,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use image::GenericImageView;
+use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use wasmtime::*;
 
+use crate::audio_format;
 use crate::bookmarks::SharedBookmarkStore;
 use crate::engine::ModuleLoader;
 use crate::navigation::NavigationStack;
@@ -144,6 +146,8 @@ pub struct HostState {
     pub bookmark_store: SharedBookmarkStore,
     /// Audio playback engine (lazily initialised on first audio API call).
     pub audio: Arc<Mutex<Option<AudioEngine>>>,
+    /// `Content-Type` from the last `api_audio_play_url` response (UTF-8), for codec negotiation introspection.
+    pub last_audio_url_content_type: Arc<Mutex<String>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -411,6 +415,7 @@ impl Default for HostState {
             canvas_offset: Arc::new(Mutex::new((0.0, 0.0))),
             bookmark_store: crate::bookmarks::new_shared(),
             audio: Arc::new(Mutex::new(None)),
+            last_audio_url_content_type: Arc::new(Mutex::new(String::new())),
         }
     }
 }
@@ -476,6 +481,28 @@ pub fn console_log(console: &Arc<Mutex<Vec<ConsoleEntry>>>, level: ConsoleLevel,
         level,
         message,
     });
+}
+
+fn audio_try_play(
+    engine: &mut AudioEngine,
+    channel: u32,
+    data: Vec<u8>,
+    format_hint: u32,
+    console: &Arc<Mutex<Vec<ConsoleEntry>>>,
+) -> bool {
+    let sniffed = audio_format::sniff_audio_format(&data);
+    if format_hint != 0
+        && format_hint != audio_format::AUDIO_FORMAT_UNKNOWN
+        && sniffed != audio_format::AUDIO_FORMAT_UNKNOWN
+        && sniffed != format_hint
+    {
+        console_log(
+            console,
+            ConsoleLevel::Warn,
+            format!("[AUDIO] Format hint {format_hint} does not match sniffed container {sniffed}"),
+        );
+    }
+    engine.play_bytes_on(channel, data)
 }
 
 /// Register every `oxide` import on `linker` so guest modules can link against them.
@@ -1843,6 +1870,61 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
 
     linker.func_wrap(
         "oxide",
+        "api_audio_detect_format",
+        |caller: Caller<'_, HostState>, data_ptr: u32, data_len: u32| -> u32 {
+            let mem = caller.data().memory.expect("memory not set");
+            let data = read_guest_bytes(&mem, &caller, data_ptr, data_len).unwrap_or_default();
+            audio_format::sniff_audio_format(&data)
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_audio_play_with_format",
+        |caller: Caller<'_, HostState>, data_ptr: u32, data_len: u32, format_hint: u32| -> i32 {
+            let mem = caller.data().memory.expect("memory not set");
+            let data = read_guest_bytes(&mem, &caller, data_ptr, data_len).unwrap_or_default();
+            if data.is_empty() {
+                return -1;
+            }
+
+            let audio = caller.data().audio.clone();
+            let mut guard = audio.lock().unwrap();
+            if guard.is_none() {
+                *guard = AudioEngine::try_new();
+            }
+            match guard.as_mut() {
+                Some(engine) => {
+                    if audio_try_play(engine, 0, data, format_hint, &caller.data().console) {
+                        console_log(
+                            &caller.data().console,
+                            ConsoleLevel::Log,
+                            "[AUDIO] Playing from bytes (with format hint)".into(),
+                        );
+                        0
+                    } else {
+                        console_log(
+                            &caller.data().console,
+                            ConsoleLevel::Error,
+                            "[AUDIO] Failed to decode audio data".into(),
+                        );
+                        -2
+                    }
+                }
+                None => {
+                    console_log(
+                        &caller.data().console,
+                        ConsoleLevel::Error,
+                        "[AUDIO] No audio device available".into(),
+                    );
+                    -3
+                }
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
         "api_audio_play_url",
         |caller: Caller<'_, HostState>, url_ptr: u32, url_len: u32| -> i32 {
             let mem = caller.data().memory.expect("memory not set");
@@ -1854,25 +1936,36 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                 format!("[AUDIO] Fetching {url}"),
             );
 
-            let (tx, rx) = std::sync::mpsc::sync_channel::<Result<Vec<u8>, String>>(1);
+            let (tx, rx) =
+                std::sync::mpsc::sync_channel::<Result<(Vec<u8>, Option<String>), String>>(1);
             let fetch_url = url.clone();
             std::thread::spawn(move || {
-                let result = (|| -> Result<Vec<u8>, String> {
+                let result = (|| -> Result<(Vec<u8>, Option<String>), String> {
                     let client = reqwest::blocking::Client::builder()
                         .timeout(Duration::from_secs(30))
                         .build()
                         .map_err(|e| e.to_string())?;
-                    let resp = client.get(&fetch_url).send().map_err(|e| e.to_string())?;
+                    let resp = client
+                        .get(&fetch_url)
+                        .header(ACCEPT, audio_format::AUDIO_HTTP_ACCEPT)
+                        .send()
+                        .map_err(|e| e.to_string())?;
                     if !resp.status().is_success() {
                         return Err(format!("HTTP {}", resp.status()));
                     }
-                    resp.bytes().map(|b| b.to_vec()).map_err(|e| e.to_string())
+                    let ct = resp
+                        .headers()
+                        .get(CONTENT_TYPE)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_string());
+                    let bytes = resp.bytes().map(|b| b.to_vec()).map_err(|e| e.to_string())?;
+                    Ok((bytes, ct))
                 })();
                 let _ = tx.send(result);
             });
 
-            let data = match rx.recv() {
-                Ok(Ok(bytes)) => bytes,
+            let (data, content_type) = match rx.recv() {
+                Ok(Ok(pair)) => pair,
                 Ok(Err(e)) => {
                     console_log(
                         &caller.data().console,
@@ -1884,6 +1977,37 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                 Err(_) => return -1,
             };
 
+            *caller.data().last_audio_url_content_type.lock().unwrap() =
+                content_type.clone().unwrap_or_default();
+
+            let sniffed = audio_format::sniff_audio_format(&data);
+            if let Some(ref ct) = content_type {
+                if audio_format::is_likely_non_audio_document(ct)
+                    && sniffed == audio_format::AUDIO_FORMAT_UNKNOWN
+                {
+                    console_log(
+                        &caller.data().console,
+                        ConsoleLevel::Error,
+                        "[AUDIO] Response is not a supported audio resource (document MIME, no audio signature)"
+                            .into(),
+                    );
+                    return -4;
+                }
+                let mime_fmt = audio_format::mime_to_audio_format(ct);
+                if mime_fmt != audio_format::AUDIO_FORMAT_UNKNOWN
+                    && sniffed != audio_format::AUDIO_FORMAT_UNKNOWN
+                    && mime_fmt != sniffed
+                {
+                    console_log(
+                        &caller.data().console,
+                        ConsoleLevel::Warn,
+                        format!(
+                            "[AUDIO] Content-Type disagrees with sniffed container (MIME -> {mime_fmt}, sniff -> {sniffed})"
+                        ),
+                    );
+                }
+            }
+
             let audio = caller.data().audio.clone();
             let mut guard = audio.lock().unwrap();
             if guard.is_none() {
@@ -1892,10 +2016,11 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
             match guard.as_mut() {
                 Some(engine) => {
                     if engine.play_bytes_on(0, data) {
+                        let ct = content_type.as_deref().unwrap_or("(none)");
                         console_log(
                             &caller.data().console,
                             ConsoleLevel::Log,
-                            format!("[AUDIO] Playing from URL: {url}"),
+                            format!("[AUDIO] Playing from URL: {url} (Content-Type: {ct})"),
                         );
                         0
                     } else {
@@ -1916,6 +2041,24 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                     -3
                 }
             }
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_audio_last_url_content_type",
+        |mut caller: Caller<'_, HostState>, out_ptr: u32, out_cap: u32| -> u32 {
+            let s = caller
+                .data()
+                .last_audio_url_content_type
+                .lock()
+                .unwrap()
+                .clone();
+            let bytes = s.as_bytes();
+            let write_len = bytes.len().min(out_cap as usize);
+            let mem = caller.data().memory.expect("memory not set");
+            write_guest_bytes(&mem, &mut caller, out_ptr, &bytes[..write_len]).ok();
+            write_len as u32
         },
     )?;
 
@@ -2093,6 +2236,49 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                             &caller.data().console,
                             ConsoleLevel::Log,
                             format!("[AUDIO] Playing on channel {channel}"),
+                        );
+                        0
+                    } else {
+                        console_log(
+                            &caller.data().console,
+                            ConsoleLevel::Error,
+                            format!("[AUDIO] Failed to decode audio for channel {channel}"),
+                        );
+                        -2
+                    }
+                }
+                None => -3,
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_audio_channel_play_with_format",
+        |caller: Caller<'_, HostState>,
+         channel: u32,
+         data_ptr: u32,
+         data_len: u32,
+         format_hint: u32|
+         -> i32 {
+            let mem = caller.data().memory.expect("memory not set");
+            let data = read_guest_bytes(&mem, &caller, data_ptr, data_len).unwrap_or_default();
+            if data.is_empty() {
+                return -1;
+            }
+
+            let audio = caller.data().audio.clone();
+            let mut guard = audio.lock().unwrap();
+            if guard.is_none() {
+                *guard = AudioEngine::try_new();
+            }
+            match guard.as_mut() {
+                Some(engine) => {
+                    if audio_try_play(engine, channel, data, format_hint, &caller.data().console) {
+                        console_log(
+                            &caller.data().console,
+                            ConsoleLevel::Log,
+                            format!("[AUDIO] Playing on channel {channel} (with format hint)"),
                         );
                         0
                     } else {

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -61,6 +61,7 @@
 //! - **Capability-based I/O** — only explicitly provided `oxide::*` functions
 //!   are available to the guest
 
+pub mod audio_format;
 pub mod bookmarks;
 pub mod capabilities;
 pub mod engine;

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -65,7 +65,7 @@
 //! | **HTTP** | [`fetch`], [`fetch_get`], [`fetch_post`], [`fetch_post_proto`], [`fetch_put`], [`fetch_delete`] |
 //! | **Protobuf** | [`proto::ProtoEncoder`], [`proto::ProtoDecoder`] |
 //! | **Storage** | [`storage_set`], [`storage_get`], [`storage_remove`], [`kv_store_set`], [`kv_store_get`], [`kv_store_delete`] |
-//! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_pause`], [`audio_resume`], [`audio_stop`], [`audio_set_volume`], [`audio_channel_play`] |
+//! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_detect_format`], [`audio_play_with_format`], [`audio_last_url_content_type`], [`audio_pause`], [`audio_channel_play`] |
 //! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
 //! | **Input** | [`mouse_position`], [`mouse_button_down`], [`key_down`], [`key_pressed`], [`scroll_delta`] |
@@ -305,6 +305,15 @@ extern "C" {
     #[link_name = "api_audio_play_url"]
     fn _api_audio_play_url(url_ptr: u32, url_len: u32) -> i32;
 
+    #[link_name = "api_audio_detect_format"]
+    fn _api_audio_detect_format(data_ptr: u32, data_len: u32) -> u32;
+
+    #[link_name = "api_audio_play_with_format"]
+    fn _api_audio_play_with_format(data_ptr: u32, data_len: u32, format_hint: u32) -> i32;
+
+    #[link_name = "api_audio_last_url_content_type"]
+    fn _api_audio_last_url_content_type(out_ptr: u32, out_cap: u32) -> u32;
+
     #[link_name = "api_audio_pause"]
     fn _api_audio_pause();
 
@@ -337,6 +346,14 @@ extern "C" {
 
     #[link_name = "api_audio_channel_play"]
     fn _api_audio_channel_play(channel: u32, data_ptr: u32, data_len: u32) -> i32;
+
+    #[link_name = "api_audio_channel_play_with_format"]
+    fn _api_audio_channel_play_with_format(
+        channel: u32,
+        data_ptr: u32,
+        data_len: u32,
+        format_hint: u32,
+    ) -> i32;
 
     #[link_name = "api_audio_channel_stop"]
     fn _api_audio_channel_stop(channel: u32);
@@ -576,17 +593,71 @@ pub fn notify(title: &str, body: &str) {
 
 // ─── Audio Playback API ─────────────────────────────────────────────────────
 
+/// Detected or hinted audio container (host codes: 0 unknown, 1 WAV, 2 MP3, 3 Ogg, 4 FLAC).
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AudioFormat {
+    /// Could not classify from bytes (try decode anyway).
+    Unknown = 0,
+    Wav = 1,
+    Mp3 = 2,
+    Ogg = 3,
+    Flac = 4,
+}
+
+impl From<u32> for AudioFormat {
+    fn from(code: u32) -> Self {
+        match code {
+            1 => AudioFormat::Wav,
+            2 => AudioFormat::Mp3,
+            3 => AudioFormat::Ogg,
+            4 => AudioFormat::Flac,
+            _ => AudioFormat::Unknown,
+        }
+    }
+}
+
+impl From<AudioFormat> for u32 {
+    fn from(f: AudioFormat) -> u32 {
+        f as u32
+    }
+}
+
 /// Play audio from encoded bytes (WAV, MP3, OGG, FLAC).
 /// The host decodes and plays the audio. Returns 0 on success, negative on error.
 pub fn audio_play(data: &[u8]) -> i32 {
     unsafe { _api_audio_play(data.as_ptr() as u32, data.len() as u32) }
 }
 
+/// Sniff the container/codec from raw bytes (magic bytes / MP3 sync). Does not decode audio.
+pub fn audio_detect_format(data: &[u8]) -> AudioFormat {
+    let code = unsafe { _api_audio_detect_format(data.as_ptr() as u32, data.len() as u32) };
+    AudioFormat::from(code)
+}
+
+/// Play with an optional format hint (`AudioFormat::Unknown` = same as [`audio_play`]).
+/// If the hint disagrees with what the host sniffs from the bytes, the host logs a warning but still decodes.
+pub fn audio_play_with_format(data: &[u8], format: AudioFormat) -> i32 {
+    unsafe {
+        _api_audio_play_with_format(data.as_ptr() as u32, data.len() as u32, u32::from(format))
+    }
+}
+
 /// Fetch audio from a URL and play it.
-/// The host performs the HTTP fetch and decodes the audio.
+/// The host sends an `Accept` header listing supported codecs, records the response `Content-Type`,
+/// and rejects obvious HTML/JSON error bodies when no audio signature is found (`-4`).
 /// Returns 0 on success, negative on error.
 pub fn audio_play_url(url: &str) -> i32 {
     unsafe { _api_audio_play_url(url.as_ptr() as u32, url.len() as u32) }
+}
+
+/// `Content-Type` header from the last successful [`audio_play_url`] response (may be empty).
+pub fn audio_last_url_content_type() -> String {
+    let mut buf = [0u8; 512];
+    let len =
+        unsafe { _api_audio_last_url_content_type(buf.as_mut_ptr() as u32, buf.len() as u32) };
+    let n = (len as usize).min(buf.len());
+    String::from_utf8_lossy(&buf[..n]).to_string()
 }
 
 /// Pause audio playback.
@@ -648,6 +719,18 @@ pub fn audio_set_loop(enabled: bool) {
 /// sound effects, background music, etc.
 pub fn audio_channel_play(channel: u32, data: &[u8]) -> i32 {
     unsafe { _api_audio_channel_play(channel, data.as_ptr() as u32, data.len() as u32) }
+}
+
+/// Like [`audio_channel_play`] with an optional [`AudioFormat`] hint.
+pub fn audio_channel_play_with_format(channel: u32, data: &[u8], format: AudioFormat) -> i32 {
+    unsafe {
+        _api_audio_channel_play_with_format(
+            channel,
+            data.as_ptr() as u32,
+            data.len() as u32,
+            u32::from(format),
+        )
+    }
 }
 
 /// Stop playback on a specific channel.


### PR DESCRIPTION
Implement Phase 1 roadmap item for sniffing audio containers (WAV, MP3, Ogg, FLAC) from magic bytes and MP3 sync, mapping Content-Type to the same codes, and rejecting obvious non-audio document responses when no audio signature is present.

Host (oxide-browser):
- Add audio_format module with sniffing, MIME helpers, AUDIO_HTTP_ACCEPT, and unit tests.
- Register api_audio_detect_format, api_audio_play_with_format, api_audio_channel_play_with_format, api_audio_last_url_content_type.
- Extend api_audio_play_url with Accept header, Content-Type capture, MIME vs sniff warnings, and fast-fail (-4) for document-like bodies.
- Add HostState::last_audio_url_content_type and audio_try_play hint helper with mismatch warnings.

SDK (oxide-sdk):
- Add AudioFormat enum and wrappers for detect, play with hint, channel play with hint, and last URL Content-Type string.

ROADMAP: mark Audio format detection and codec negotiation as shipped.
Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic audio format detection for WAV, MP3, OGG, and FLAC formats
  * Introduced enhanced audio playback APIs with format hint support for improved control
  * Improved content-type detection and validation when fetching audio from URLs
  * Enhanced error handling to reject non-audio document responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->