### PR TITLE
feat: add media capture APIs, wasm example, and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
             libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev \
             libasound2-dev \
             pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev \
-            libavdevice-dev libswscale-dev libswresample-dev
+            libavdevice-dev libswscale-dev libswresample-dev \
+            libv4l-dev
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -60,5 +61,7 @@ jobs:
       - name: Check SDK
         run: cargo check -p oxide-sdk --target wasm32-unknown-unknown
 
-      - name: Check example
-        run: cargo check -p hello-oxide --target wasm32-unknown-unknown
+      - name: Check examples (wasm32)
+        run: |
+          cargo check -p hello-oxide --target wasm32-unknown-unknown
+          cargo check -p media-capture --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "examples/fullstack-notes/backend",
     "examples/index",
     "examples/video-player",
+    "examples/media-capture",
 ]
 resolver = "2"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,10 +58,10 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 
 ### Media Capture
 
-- [ ] `camera_open()` / `camera_capture_frame()` — access device camera with user permission prompt
-- [ ] `microphone_open()` / `microphone_read_samples()` — access microphone input
-- [ ] `screen_capture()` — screenshot or screen recording with permission
-- [ ] Media stream pipelines for real-time processing
+- [x] `camera_open()` / `camera_capture_frame()` — access device camera with user permission prompt
+- [x] `microphone_open()` / `microphone_read_samples()` — access microphone input
+- [x] `screen_capture()` — screenshot or screen recording with permission
+- [x] Media stream pipelines for real-time processing (host `api_media_pipeline_stats`; guests compose frames/samples in Wasm)
 
 ---
 

--- a/examples/index/src/lib.rs
+++ b/examples/index/src/lib.rs
@@ -11,6 +11,7 @@ const CARD_HOVER: (u8, u8, u8) = (42, 38, 68);
 const GREEN: (u8, u8, u8) = (80, 220, 140);
 const BLUE: (u8, u8, u8) = (80, 160, 240);
 const ORANGE: (u8, u8, u8) = (240, 170, 60);
+const PURPLE: (u8, u8, u8) = (160, 90, 220);
 const DIVIDER: (u8, u8, u8) = (50, 45, 70);
 
 struct Card {
@@ -46,6 +47,14 @@ const CARDS: &[Card] = &[
         url: "https://oxide.foundation/timer_demo.wasm",
         color: ORANGE,
         icon_char: "T",
+    },
+    Card {
+        title: "Media Capture",
+        subtitle: "media_capture.wasm",
+        description: "Camera preview, microphone level, and screen screenshot.",
+        url: "https://oxide.foundation/media_capture.wasm",
+        color: PURPLE,
+        icon_char: "M",
     },
 ];
 

--- a/examples/media-capture/Cargo.toml
+++ b/examples/media-capture/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "media-capture"
+version = "0.1.0"
+edition = "2021"
+description = "Camera, microphone, and screen capture demo for the Oxide browser"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }
+png = "0.17"

--- a/examples/media-capture/src/lib.rs
+++ b/examples/media-capture/src/lib.rs
@@ -1,0 +1,243 @@
+//! Demonstrates [`oxide_sdk`] media capture: camera preview (PNG-encoded for [`canvas_image`]),
+//! microphone level meter, and a screen screenshot thumbnail.
+
+use oxide_sdk::*;
+
+use png::Encoder;
+
+/// RGBA buffers for camera and screen (filled by host; we encode to PNG for `canvas_image`).
+const MAX_RGBA: usize = 1920 * 1080 * 4;
+
+static mut CAM_BUF: Vec<u8> = Vec::new();
+static mut SCR_BUF: Vec<u8> = Vec::new();
+static mut CAMERA_ON: bool = false;
+static mut MIC_ON: bool = false;
+static mut MIC_SMOOTH: f32 = 0.0;
+static mut LAST_SCR_OK: bool = false;
+static mut SCR_BYTES: usize = 0;
+
+fn rgba_to_png(width: u32, height: u32, rgba: &[u8]) -> Option<Vec<u8>> {
+    let expected = (width as usize)
+        .checked_mul(height as usize)?
+        .checked_mul(4)?;
+    if rgba.len() < expected {
+        return None;
+    }
+    let mut out = Vec::new();
+    {
+        let mut enc = Encoder::new(&mut out, width, height);
+        enc.set_color(png::ColorType::Rgba);
+        enc.set_depth(png::BitDepth::Eight);
+        let mut writer = enc.write_header().ok()?;
+        writer.write_image_data(&rgba[..expected]).ok()?;
+    }
+    Some(out)
+}
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("Media capture demo — approve camera, microphone, and screen when prompted.");
+    unsafe {
+        CAM_BUF = vec![0u8; MAX_RGBA];
+        SCR_BUF = vec![0u8; MAX_RGBA];
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let (cw, ch) = canvas_dimensions();
+    let w = cw as f32;
+    let h = ch as f32;
+
+    canvas_clear(18, 20, 28, 255);
+
+    canvas_text(20.0, 16.0, 22.0, 220, 210, 255, "Media capture");
+    canvas_text(
+        20.0,
+        44.0,
+        13.0,
+        140,
+        150,
+        170,
+        "Camera / mic / screenshot use host dialogs + OS permissions.",
+    );
+
+    let preview_x = 20.0;
+    let preview_y = 72.0;
+    let preview_w = (w - 40.0).max(200.0);
+    // Reserve vertical space for buttons, thumbnail, and mic meter.
+    let preview_h = (h - 260.0).clamp(100.0, 280.0);
+    let btn_row_y = preview_y + preview_h + 12.0;
+    let thumb_x = 20.0;
+    let thumb_y = btn_row_y + 80.0;
+    let thumb_w = (w - 40.0).min(420.0);
+    let thumb_h = 110.0;
+    let meter_y = thumb_y + thumb_h + 36.0;
+
+    // ── Buttons ───────────────────────────────────────────────────────
+    if ui_button(1, 20.0, btn_row_y, 140.0, 32.0, "Open camera") {
+        unsafe {
+            let code = camera_open();
+            if code == 0 {
+                CAMERA_ON = true;
+                log("camera_open OK");
+            } else {
+                log(&format!("camera_open failed: {code}"));
+            }
+        }
+    }
+    if ui_button(2, 175.0, btn_row_y, 120.0, 32.0, "Close camera") {
+        unsafe {
+            camera_close();
+            CAMERA_ON = false;
+        }
+    }
+    if ui_button(3, 20.0, btn_row_y + 44.0, 140.0, 32.0, "Open mic") {
+        unsafe {
+            let code = microphone_open();
+            if code == 0 {
+                MIC_ON = true;
+                log("microphone_open OK");
+            } else {
+                log(&format!("microphone_open failed: {code}"));
+            }
+        }
+    }
+    if ui_button(4, 175.0, btn_row_y + 44.0, 120.0, 32.0, "Close mic") {
+        unsafe {
+            microphone_close();
+            MIC_ON = false;
+            MIC_SMOOTH = 0.0;
+        }
+    }
+    if ui_button(5, 310.0, btn_row_y, 160.0, 32.0, "Screenshot") {
+        unsafe {
+            match screen_capture(&mut SCR_BUF[..]) {
+                Ok(n) if n > 0 => {
+                    LAST_SCR_OK = true;
+                    SCR_BYTES = n;
+                    log(&format!("screen_capture OK ({n} bytes)"));
+                }
+                Ok(_) => log("screen_capture: 0 bytes"),
+                Err(e) => log(&format!("screen_capture failed: {e}")),
+            }
+        }
+    }
+
+    // ── Camera preview ────────────────────────────────────────────────
+    unsafe {
+        if CAMERA_ON {
+            let n = camera_capture_frame(&mut CAM_BUF[..]) as usize;
+            let (iw, ih) = camera_frame_dimensions();
+            let expected = (iw as usize).saturating_mul(ih as usize).saturating_mul(4);
+            if n > 0 && n == expected {
+                if let Some(png) = rgba_to_png(iw, ih, &CAM_BUF[..n]) {
+                    canvas_image(preview_x, preview_y, preview_w, preview_h, &png);
+                }
+            }
+        } else {
+            canvas_rect(preview_x, preview_y, preview_w, preview_h, 35, 38, 48, 255);
+            canvas_text(
+                preview_x + 12.0,
+                preview_y + preview_h * 0.45,
+                16.0,
+                120,
+                128,
+                140,
+                "Open camera to preview",
+            );
+        }
+    }
+
+    // ── Screen thumbnail (below controls; drawn before mic so the meter stays on top) ──
+    canvas_text(
+        thumb_x,
+        thumb_y - 18.0,
+        13.0,
+        160,
+        165,
+        180,
+        "Last screenshot",
+    );
+
+    unsafe {
+        if LAST_SCR_OK {
+            let (sw, sh) = screen_capture_dimensions();
+            let exp = (sw as usize).saturating_mul(sh as usize).saturating_mul(4);
+            if exp > 0 && SCR_BYTES >= exp && exp <= MAX_RGBA {
+                if let Some(png) = rgba_to_png(sw, sh, &SCR_BUF[..exp]) {
+                    canvas_image(thumb_x, thumb_y, thumb_w, thumb_h, &png);
+                }
+            }
+        } else {
+            canvas_rect(thumb_x, thumb_y, thumb_w, thumb_h, 32, 36, 42, 255);
+            canvas_text(
+                thumb_x + 24.0,
+                thumb_y + 48.0,
+                13.0,
+                100,
+                110,
+                125,
+                "No grab yet",
+            );
+        }
+    }
+
+    // ── Mic level ─────────────────────────────────────────────────────
+    let meter_x = 20.0;
+    let meter_w = (w - 40.0).min(520.0);
+    canvas_text(
+        meter_x,
+        meter_y - 22.0,
+        14.0,
+        180,
+        185,
+        200,
+        "Microphone (mono)",
+    );
+    canvas_rect(meter_x, meter_y, meter_w, 14.0, 40, 44, 52, 255);
+
+    unsafe {
+        if MIC_ON {
+            let mut samples = [0.0f32; 4096];
+            let got = microphone_read_samples(&mut samples);
+            if got > 0 {
+                let g = got as usize;
+                let mut acc = 0.0f32;
+                for s in samples.iter().take(g) {
+                    acc += s * s;
+                }
+                let rms = (acc / g as f32).sqrt();
+                MIC_SMOOTH = MIC_SMOOTH * 0.85 + rms * 0.15;
+            }
+            let level = (MIC_SMOOTH * 8.0).min(1.0);
+            let fill = meter_w * level;
+            canvas_rect(meter_x, meter_y, fill, 14.0, 80, 200, 140, 255);
+            let hz = microphone_sample_rate();
+            canvas_text(
+                meter_x + meter_w + 12.0,
+                meter_y - 2.0,
+                12.0,
+                130,
+                140,
+                155,
+                &format!("{hz} Hz"),
+            );
+        } else {
+            canvas_text(meter_x + 8.0, meter_y - 2.0, 12.0, 100, 110, 125, "closed");
+        }
+    }
+
+    // ── Pipeline stats ────────────────────────────────────────────────
+    let (frames, ring) = media_pipeline_stats();
+    let footer_y = (meter_y + 36.0).min(h - 18.0);
+    canvas_text(
+        20.0,
+        footer_y,
+        11.0,
+        90,
+        95,
+        105,
+        &format!("pipeline: cam_frames={frames} mic_ring~{ring}"),
+    );
+}

--- a/oxide-browser/Cargo.toml
+++ b/oxide-browser/Cargo.toml
@@ -35,6 +35,9 @@ getrandom = "0.2"
 rodio = "0.22.2"
 ffmpeg-next = "8.1.0"
 tempfile = "3"
+nokhwa = { version = "0.10.10", features = ["input-native", "camera-sync-impl"] }
+cpal = "0.17.3"
+screenshots = "0.8.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -157,6 +157,8 @@ pub struct HostState {
     pub video_pip_frame: Arc<Mutex<Option<DecodedImage>>>,
     /// Bumped when the PiP buffer is updated so the UI can refresh the floating texture.
     pub video_pip_serial: Arc<Mutex<u64>>,
+    /// Camera, microphone, and screen capture (permission prompts + native APIs).
+    pub media_capture: Arc<Mutex<crate::media_capture::MediaCaptureState>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -428,6 +430,9 @@ impl Default for HostState {
             video: Arc::new(Mutex::new(VideoPlaybackState::default())),
             video_pip_frame: Arc::new(Mutex::new(None)),
             video_pip_serial: Arc::new(Mutex::new(0)),
+            media_capture: Arc::new(Mutex::new(
+                crate::media_capture::MediaCaptureState::default(),
+            )),
         }
     }
 }
@@ -527,7 +532,7 @@ fn read_guest_bytes(
     Ok(data.to_vec())
 }
 
-fn write_guest_bytes(
+pub(crate) fn write_guest_bytes(
     memory: &Memory,
     store: &mut impl AsContextMut,
     ptr: u32,
@@ -2898,6 +2903,8 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
             write_len as u32
         },
     )?;
+
+    crate::media_capture::register_media_capture_functions(linker)?;
 
     Ok(())
 }

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -44,6 +44,7 @@
 //! | [`engine`] | Wasmtime engine configuration, sandbox policy, memory bounds |
 //! | [`runtime`] | Module fetching, compilation, execution lifecycle |
 //! | [`capabilities`] | All host-imported functions exposed to guest wasm modules |
+//! | [`media_capture`] | Camera, microphone, and screen capture with permission prompts |
 //! | [`navigation`] | Browser history stack with back/forward traversal |
 //! | [`bookmarks`] | Persistent bookmark storage backed by sled |
 //! | [`url`] | WHATWG-compliant URL parsing with Oxide-specific schemes |
@@ -65,6 +66,7 @@ pub mod audio_format;
 pub mod bookmarks;
 pub mod capabilities;
 pub mod engine;
+pub mod media_capture;
 pub mod navigation;
 pub mod runtime;
 pub mod subtitle;

--- a/oxide-browser/src/media_capture.rs
+++ b/oxide-browser/src/media_capture.rs
@@ -1,0 +1,453 @@
+//! Host-side media capture: camera, microphone, and screen (with permission prompts).
+//!
+//! Guests call [`register_media_capture_functions`] imports from the `oxide` module. Native
+//! OS prompts (camera / microphone / screen recording) may appear in addition to Oxide’s
+//! in-app confirmation dialogs.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::SampleFormat;
+use nokhwa::pixel_format::RgbFormat;
+use nokhwa::utils::{CameraIndex, RequestedFormat, RequestedFormatType};
+use nokhwa::Camera;
+use wasmtime::{Caller, Linker};
+
+use crate::capabilities::{console_log, write_guest_bytes, ConsoleLevel, HostState};
+
+const MIC_RING_CAP: usize = 96_000;
+
+/// Shared capture state for a tab (camera stream, mic ring buffer, counters for pipeline stats).
+#[derive(Default)]
+pub struct MediaCaptureState {
+    camera: Option<Camera>,
+    last_frame_w: u32,
+    last_frame_h: u32,
+    camera_frames: u64,
+    microphone: Option<MicrophoneInput>,
+    screen_w: u32,
+    screen_h: u32,
+    screen_captures: u64,
+}
+
+struct MicrophoneInput {
+    #[allow(dead_code)]
+    stream: cpal::Stream,
+    buffer: Arc<Mutex<VecDeque<f32>>>,
+    sample_rate: u32,
+}
+
+fn prompt(feature: &str) -> bool {
+    matches!(
+        rfd::MessageDialog::new()
+            .set_title("Oxide")
+            .set_description(format!("Allow this page to access {feature}?"))
+            .set_buttons(rfd::MessageButtons::OkCancel)
+            .show(),
+        rfd::MessageDialogResult::Ok | rfd::MessageDialogResult::Yes
+    )
+}
+
+fn push_mono_f32(data: &[f32], channels: usize, ring: &Arc<Mutex<VecDeque<f32>>>) {
+    let ch = channels.max(1);
+    let frames = data.len() / ch;
+    let mut q = ring.lock().unwrap();
+    for i in 0..frames {
+        let mut sum = 0.0f32;
+        for c in 0..ch {
+            sum += data[i * ch + c];
+        }
+        let m = sum / ch as f32;
+        while q.len() >= MIC_RING_CAP {
+            q.pop_front();
+        }
+        q.push_back(m);
+    }
+}
+
+fn push_mono_i16(data: &[i16], channels: usize, ring: &Arc<Mutex<VecDeque<f32>>>) {
+    let ch = channels.max(1);
+    let frames = data.len() / ch;
+    let mut q = ring.lock().unwrap();
+    for i in 0..frames {
+        let mut sum = 0.0f32;
+        for c in 0..ch {
+            sum += data[i * ch + c] as f32 / 32768.0;
+        }
+        let m = sum / ch as f32;
+        while q.len() >= MIC_RING_CAP {
+            q.pop_front();
+        }
+        q.push_back(m);
+    }
+}
+
+fn push_mono_u16(data: &[u16], channels: usize, ring: &Arc<Mutex<VecDeque<f32>>>) {
+    let ch = channels.max(1);
+    let frames = data.len() / ch;
+    let mut q = ring.lock().unwrap();
+    for i in 0..frames {
+        let mut sum = 0.0f32;
+        for c in 0..ch {
+            sum += (data[i * ch + c] as f32 - 32768.0) / 32768.0;
+        }
+        let m = sum / ch as f32;
+        while q.len() >= MIC_RING_CAP {
+            q.pop_front();
+        }
+        q.push_back(m);
+    }
+}
+
+fn open_microphone(
+    console: &Arc<Mutex<Vec<crate::capabilities::ConsoleEntry>>>,
+) -> Result<MicrophoneInput, i32> {
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| log_err(console, -2, "[MIC] No input device".to_string()))?;
+    let supported = match device.default_input_config() {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(log_err(console, -3, format!("[MIC] Config: {e}")));
+        }
+    };
+    let sample_format = supported.sample_format();
+    let config: cpal::StreamConfig = supported.clone().into();
+    let channels = config.channels as usize;
+    let ring = Arc::new(Mutex::new(VecDeque::with_capacity(MIC_RING_CAP)));
+    let ring2 = ring.clone();
+    let console_err = console.clone();
+    let err_fn = move |e| {
+        console_log(
+            &console_err,
+            ConsoleLevel::Warn,
+            format!("[MIC] Stream error: {e}"),
+        );
+    };
+
+    let stream = match sample_format {
+        SampleFormat::F32 => device.build_input_stream(
+            &config,
+            move |data: &[f32], _| push_mono_f32(data, channels, &ring2),
+            err_fn,
+            None,
+        ),
+        SampleFormat::I16 => device.build_input_stream(
+            &config,
+            move |data: &[i16], _| push_mono_i16(data, channels, &ring2),
+            err_fn,
+            None,
+        ),
+        SampleFormat::U16 => device.build_input_stream(
+            &config,
+            move |data: &[u16], _| push_mono_u16(data, channels, &ring2),
+            err_fn,
+            None,
+        ),
+        other => {
+            return Err(log_err(
+                console,
+                -3,
+                format!("[MIC] Unsupported sample format {other:?}"),
+            ));
+        }
+    };
+    let stream = match stream {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(log_err(console, -3, format!("[MIC] Build stream: {e}")));
+        }
+    };
+    if let Err(e) = stream.play() {
+        return Err(log_err(console, -3, format!("[MIC] Play: {e}")));
+    }
+    let sample_rate = supported.sample_rate();
+    Ok(MicrophoneInput {
+        stream,
+        buffer: ring,
+        sample_rate,
+    })
+}
+
+fn log_err(
+    console: &Arc<Mutex<Vec<crate::capabilities::ConsoleEntry>>>,
+    code: i32,
+    msg: String,
+) -> i32 {
+    console_log(console, ConsoleLevel::Warn, msg);
+    code
+}
+
+/// Register `api_camera_*`, `api_microphone_*`, `api_screen_capture`, and `api_media_pipeline_stats`.
+pub fn register_media_capture_functions(linker: &mut Linker<HostState>) -> Result<()> {
+    linker.func_wrap(
+        "oxide",
+        "api_camera_open",
+        |caller: Caller<'_, HostState>| -> i32 {
+            let console = caller.data().console.clone();
+            let st = caller.data().media_capture.clone();
+            if !prompt("the camera") {
+                return -1;
+            }
+            let mut g = st.lock().unwrap();
+            if let Some(mut cam) = g.camera.take() {
+                let _ = cam.stop_stream();
+            }
+            let cams = match nokhwa::query(nokhwa::utils::ApiBackend::Auto) {
+                Ok(c) => c,
+                Err(e) => {
+                    return log_err(&console, -2, format!("[CAMERA] No cameras: {e}"));
+                }
+            };
+            if cams.is_empty() {
+                return log_err(&console, -2, "[CAMERA] No cameras found".to_string());
+            }
+            let req =
+                RequestedFormat::new::<RgbFormat>(RequestedFormatType::AbsoluteHighestResolution);
+            let mut camera = match Camera::new(CameraIndex::Index(0), req) {
+                Ok(c) => c,
+                Err(e) => {
+                    return log_err(&console, -3, format!("[CAMERA] Open failed: {e}"));
+                }
+            };
+            if let Err(e) = camera.open_stream() {
+                return log_err(&console, -3, format!("[CAMERA] Stream: {e}"));
+            }
+            g.camera = Some(camera);
+            0
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_camera_close",
+        |caller: Caller<'_, HostState>| {
+            let st = caller.data().media_capture.clone();
+            let mut g = st.lock().unwrap();
+            if let Some(mut cam) = g.camera.take() {
+                let _ = cam.stop_stream();
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_camera_capture_frame",
+        |mut caller: Caller<'_, HostState>, out_ptr: u32, out_cap: u32| -> u32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let st = caller.data().media_capture.clone();
+            let mut g = st.lock().unwrap();
+            let cam = match g.camera.as_mut() {
+                Some(c) => c,
+                None => return 0,
+            };
+            let buffer = match cam.frame() {
+                Ok(b) => b,
+                Err(e) => {
+                    console_log(
+                        &caller.data().console,
+                        ConsoleLevel::Warn,
+                        format!("[CAMERA] Frame: {e}"),
+                    );
+                    return 0;
+                }
+            };
+            let img = match buffer.decode_image::<RgbFormat>() {
+                Ok(i) => i,
+                Err(e) => {
+                    console_log(
+                        &caller.data().console,
+                        ConsoleLevel::Warn,
+                        format!("[CAMERA] Decode: {e}"),
+                    );
+                    return 0;
+                }
+            };
+            let w = img.width();
+            let h = img.height();
+            let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+            for px in img.pixels() {
+                let p = px.0;
+                rgba.push(p[0]);
+                rgba.push(p[1]);
+                rgba.push(p[2]);
+                rgba.push(255);
+            }
+            g.last_frame_w = w;
+            g.last_frame_h = h;
+            g.camera_frames = g.camera_frames.saturating_add(1);
+            let write_len = rgba.len().min(out_cap as usize);
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &rgba[..write_len]).is_err() {
+                return 0;
+            }
+            write_len as u32
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_camera_frame_dimensions",
+        |caller: Caller<'_, HostState>| -> u64 {
+            let g = caller.data().media_capture.lock().unwrap();
+            ((g.last_frame_w as u64) << 32) | (g.last_frame_h as u64)
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_microphone_open",
+        |caller: Caller<'_, HostState>| -> i32 {
+            let console = caller.data().console.clone();
+            let st = caller.data().media_capture.clone();
+            if !prompt("the microphone") {
+                return -1;
+            }
+            let mut g = st.lock().unwrap();
+            g.microphone = None;
+            match open_microphone(&console) {
+                Ok(m) => {
+                    g.microphone = Some(m);
+                    0
+                }
+                Err(code) => code,
+            }
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_microphone_close",
+        |caller: Caller<'_, HostState>| {
+            let st = caller.data().media_capture.clone();
+            st.lock().unwrap().microphone = None;
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_microphone_sample_rate",
+        |caller: Caller<'_, HostState>| -> u32 {
+            let g = caller.data().media_capture.lock().unwrap();
+            g.microphone.as_ref().map(|m| m.sample_rate).unwrap_or(0)
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_microphone_read_samples",
+        |mut caller: Caller<'_, HostState>, out_ptr: u32, max_samples: u32| -> u32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let st = caller.data().media_capture.clone();
+            let g = st.lock().unwrap();
+            let mic = match g.microphone.as_ref() {
+                Some(m) => m,
+                None => return 0,
+            };
+            let mut q = mic.buffer.lock().unwrap();
+            let take = (max_samples as usize).min(q.len());
+            let mut chunk = Vec::with_capacity(take * 4);
+            for _ in 0..take {
+                if let Some(s) = q.pop_front() {
+                    chunk.extend_from_slice(&s.to_le_bytes());
+                }
+            }
+            let write_len = chunk.len().min((max_samples as usize).saturating_mul(4));
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &chunk[..write_len]).is_err() {
+                return 0;
+            }
+            (write_len / 4) as u32
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_screen_capture",
+        |mut caller: Caller<'_, HostState>, out_ptr: u32, out_cap: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -4,
+            };
+            let console = caller.data().console.clone();
+            if !prompt("screen capture (the OS may also ask for screen recording permission)") {
+                return -1;
+            }
+            let screens = match screenshots::Screen::all() {
+                Ok(s) => s,
+                Err(e) => {
+                    console_log(
+                        &console,
+                        ConsoleLevel::Warn,
+                        format!("[SCREEN] Enumerate: {e}"),
+                    );
+                    return -2;
+                }
+            };
+            let screen = match screens.first() {
+                Some(s) => s,
+                None => {
+                    return log_err(&console, -2, "[SCREEN] No displays".to_string());
+                }
+            };
+            let img = match screen.capture() {
+                Ok(i) => i,
+                Err(e) => {
+                    console_log(
+                        &console,
+                        ConsoleLevel::Warn,
+                        format!("[SCREEN] Capture: {e}"),
+                    );
+                    return -3;
+                }
+            };
+            let w = img.width();
+            let h = img.height();
+            let rgba = img.into_raw();
+            let st = caller.data().media_capture.clone();
+            {
+                let mut g = st.lock().unwrap();
+                g.screen_w = w;
+                g.screen_h = h;
+                g.screen_captures = g.screen_captures.saturating_add(1);
+            }
+            let write_len = rgba.len().min(out_cap as usize);
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &rgba[..write_len]).is_err() {
+                return -4;
+            }
+            write_len as i32
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_screen_capture_dimensions",
+        |caller: Caller<'_, HostState>| -> u64 {
+            let g = caller.data().media_capture.lock().unwrap();
+            ((g.screen_w as u64) << 32) | (g.screen_h as u64)
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_media_pipeline_stats",
+        |caller: Caller<'_, HostState>| -> u64 {
+            let g = caller.data().media_capture.lock().unwrap();
+            let mic_ring = g
+                .microphone
+                .as_ref()
+                .map(|m| m.buffer.lock().unwrap().len() as u32)
+                .unwrap_or(0);
+            (g.camera_frames << 32) | (mic_ring as u64)
+        },
+    )?;
+
+    Ok(())
+}

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -67,6 +67,7 @@
 //! | **Storage** | [`storage_set`], [`storage_get`], [`storage_remove`], [`kv_store_set`], [`kv_store_get`], [`kv_store_delete`] |
 //! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_detect_format`], [`audio_play_with_format`], [`audio_last_url_content_type`], [`audio_pause`], [`audio_channel_play`] |
 //! | **Video** | [`video_load`], [`video_load_url`], [`video_render`], [`video_play`], [`video_hls_open_variant`], [`subtitle_load_srt`] |
+//! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`], [`media_pipeline_stats`] |
 //! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
 //! | **Input** | [`mouse_position`], [`mouse_button_down`], [`key_down`], [`key_pressed`], [`scroll_delta`] |
@@ -426,6 +427,41 @@ extern "C" {
 
     #[link_name = "api_subtitle_clear"]
     fn _api_subtitle_clear();
+
+    // ── Media capture ─────────────────────────────────────────────────
+
+    #[link_name = "api_camera_open"]
+    fn _api_camera_open() -> i32;
+
+    #[link_name = "api_camera_close"]
+    fn _api_camera_close();
+
+    #[link_name = "api_camera_capture_frame"]
+    fn _api_camera_capture_frame(out_ptr: u32, out_cap: u32) -> u32;
+
+    #[link_name = "api_camera_frame_dimensions"]
+    fn _api_camera_frame_dimensions() -> u64;
+
+    #[link_name = "api_microphone_open"]
+    fn _api_microphone_open() -> i32;
+
+    #[link_name = "api_microphone_close"]
+    fn _api_microphone_close();
+
+    #[link_name = "api_microphone_sample_rate"]
+    fn _api_microphone_sample_rate() -> u32;
+
+    #[link_name = "api_microphone_read_samples"]
+    fn _api_microphone_read_samples(out_ptr: u32, max_samples: u32) -> u32;
+
+    #[link_name = "api_screen_capture"]
+    fn _api_screen_capture(out_ptr: u32, out_cap: u32) -> i32;
+
+    #[link_name = "api_screen_capture_dimensions"]
+    fn _api_screen_capture_dimensions() -> u64;
+
+    #[link_name = "api_media_pipeline_stats"]
+    fn _api_media_pipeline_stats() -> u64;
 
     // ── URL Utilities ───────────────────────────────────────────────
 
@@ -953,6 +989,85 @@ pub fn subtitle_load_vtt(text: &str) -> i32 {
 
 pub fn subtitle_clear() {
     unsafe { _api_subtitle_clear() }
+}
+
+// ─── Media capture API ─────────────────────────────────────────────────────
+
+/// Opens the default camera after a host permission dialog.
+///
+/// Returns `0` on success. Negative codes: `-1` user denied, `-2` no camera, `-3` open failed.
+pub fn camera_open() -> i32 {
+    unsafe { _api_camera_open() }
+}
+
+/// Stops the camera stream opened by [`camera_open`].
+pub fn camera_close() {
+    unsafe { _api_camera_close() }
+}
+
+/// Captures one RGBA8 frame into `out`. Returns the number of bytes written (`0` if the camera
+/// is not open or capture failed). Query [`camera_frame_dimensions`] after a successful write.
+pub fn camera_capture_frame(out: &mut [u8]) -> u32 {
+    unsafe { _api_camera_capture_frame(out.as_mut_ptr() as u32, out.len() as u32) }
+}
+
+/// Width and height in pixels of the last [`camera_capture_frame`] buffer.
+pub fn camera_frame_dimensions() -> (u32, u32) {
+    let packed = unsafe { _api_camera_frame_dimensions() };
+    let w = (packed >> 32) as u32;
+    let h = packed as u32;
+    (w, h)
+}
+
+/// Starts microphone capture (mono `f32` ring buffer) after a host permission dialog.
+///
+/// Returns `0` on success. Negative codes: `-1` denied, `-2` no input device, `-3` stream error.
+pub fn microphone_open() -> i32 {
+    unsafe { _api_microphone_open() }
+}
+
+pub fn microphone_close() {
+    unsafe { _api_microphone_close() }
+}
+
+/// Sample rate of the opened input stream in Hz (`0` if the microphone is not open).
+pub fn microphone_sample_rate() -> u32 {
+    unsafe { _api_microphone_sample_rate() }
+}
+
+/// Dequeues up to `out.len()` mono `f32` samples from the microphone ring buffer.
+/// Returns how many samples were written.
+pub fn microphone_read_samples(out: &mut [f32]) -> u32 {
+    unsafe { _api_microphone_read_samples(out.as_mut_ptr() as u32, out.len() as u32) }
+}
+
+/// Captures the primary display as RGBA8 after permission dialogs (OS may prompt separately).
+///
+/// Returns `Ok(bytes_written)` or an error code: `-1` denied, `-2` no display, `-3` capture failed, `-4` buffer error.
+pub fn screen_capture(out: &mut [u8]) -> Result<usize, i32> {
+    let n = unsafe { _api_screen_capture(out.as_mut_ptr() as u32, out.len() as u32) };
+    if n >= 0 {
+        Ok(n as usize)
+    } else {
+        Err(n)
+    }
+}
+
+/// Width and height of the last [`screen_capture`] image.
+pub fn screen_capture_dimensions() -> (u32, u32) {
+    let packed = unsafe { _api_screen_capture_dimensions() };
+    let w = (packed >> 32) as u32;
+    let h = packed as u32;
+    (w, h)
+}
+
+/// Host-side pipeline counters: total camera frames captured (high 32 bits) and current microphone
+/// ring depth in samples (low 32 bits).
+pub fn media_pipeline_stats() -> (u64, u32) {
+    let packed = unsafe { _api_media_pipeline_stats() };
+    let camera_frames = packed >> 32;
+    let mic_ring = packed as u32;
+    (camera_frames, mic_ring)
 }
 
 // ─── HTTP Fetch API ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Implement Phase 1 Media Capture from the roadmap: camera (open/close, RGBA frames, dimensions), microphone (mono f32 ring buffer, sample rate, read_samples), primary-display screenshot (RGBA + dimensions), and api_media_pipeline_stats (camera frame count + mic ring depth).

Host (oxide-browser):
- New module media_capture.rs registering imports under oxide; HostState gains media_capture: Arc<Mutex<MediaCaptureState>>.
- Use nokhwa (input-native + camera-sync-impl for Send), cpal for input, screenshots for display capture; rfd dialogs before hardware access.
- pub(crate) write_guest_bytes for guest memory writes from media_capture.

SDK (oxide-sdk):
- FFI + safe wrappers: camera_*, microphone_*, screen_capture*, media_pipeline_stats; crate docs table updated.

Example (examples/media-capture):
- PNG-encode RGBA for canvas_image (host decodes encoded images only).
- UI: camera preview, mic level meter, screenshot thumbnail, pipeline footer.

Other:
- examples/index: Media Capture card linking to media_capture.wasm.
- CI: libv4l-dev (Linux camera); wasm32 check for media-capture example.
- ROADMAP: mark Media Capture items complete.