### PR TITLE
fix(browser): resolve GPUI migration bugs, add high-level drawing API…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-            libxkbcommon-dev libssl-dev libgtk-3-dev libatk1.0-dev \
+            libxkbcommon-dev libxkbcommon-x11-dev libssl-dev libgtk-3-dev libatk1.0-dev \
             libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev \
             libasound2-dev \
             pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-            libxkbcommon-dev libssl-dev libgtk-3-dev libatk1.0-dev \
+            libxkbcommon-dev libxkbcommon-x11-dev libssl-dev libgtk-3-dev libatk1.0-dev \
             libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev \
             libasound2-dev \
             pkg-config libavcodec-dev libavformat-dev libavutil-dev libavfilter-dev \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,7 @@ use oxide_sdk::*;
 #[no_mangle]
 pub extern "C" fn start_app() {
     canvas_clear(30, 30, 46, 255);
-    canvas_text(20.0, 40.0, 28.0, 255, 255, 255, "Hello, Oxide!");
+    canvas_text(20.0, 40.0, 28.0, 255, 255, 255, 255, "Hello, Oxide!");
 }
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,15 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ```
 oxide/
-├── oxide-browser/              # Host browser application (Rust, egui)
+├── oxide-browser/              # Host browser application (Rust, GPUI)
 │   └── src/
-│       ├── main.rs             # eframe bootstrap
+│       ├── main.rs             # GPUI entry — BrowserHost + run_browser
 │       ├── engine.rs           # WasmEngine, SandboxPolicy
 │       ├── runtime.rs          # BrowserHost, fetch/load/instantiate
 │       ├── capabilities.rs     # Host functions registered into wasmtime Linker
 │       ├── navigation.rs       # History stack, back/forward
 │       ├── url.rs              # WHATWG-style URL parser
-│       └── ui.rs               # egui UI — toolbar, canvas, console, widgets
+│       └── ui.rs               # GPUI shell — toolbar, canvas, console, widgets
 ├── oxide-sdk/                  # Guest-side SDK (no_std compatible, pure FFI)
 │   └── src/
 │       ├── lib.rs              # Safe Rust wrappers over host imports

--- a/DOCS.md
+++ b/DOCS.md
@@ -4,40 +4,55 @@
 
 Oxide is a **binary-first browser** that fetches and executes `.wasm` (WebAssembly) modules instead of HTML/JavaScript. Guest applications run in a secure, sandboxed environment with zero access to the host filesystem, environment variables, or arbitrary network sockets.
 
-The browser provides a set of **capability APIs** that guest modules can import to interact with the host — drawing on a canvas, reading/writing local storage, accessing the clipboard, and more.
+The browser provides a set of **capability APIs** that guest modules can import to interact with the host — drawing on a GPU-accelerated canvas, reading/writing storage, making HTTP requests, playing audio/video, capturing media, and more.
+
+The desktop shell is built on [GPUI](https://www.gpui.rs/) (Zed's GPU-accelerated UI framework). Guest draw commands map directly onto GPUI primitives — filled quads, GPU-shaped text, vector paths, and image textures — so your canvas output gets full hardware acceleration.
 
 ---
 
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────┐
-│                   Oxide Browser                  │
-│  ┌──────────┐  ┌────────────┐  ┌──────────────┐  │
-│  │  URL Bar │  │   Canvas   │  │   Console    │  │
-│  └────┬─────┘  └──────┬─────┘  └──────┬───────┘  │
-│       │               │               │          │
-│  ┌────▼───────────────▼───────────────▼───────┐  │
-│  │              Host Runtime                  │  │
-│  │  wasmtime engine + sandbox policy          │  │
-│  │  fuel limit: 500M  │  memory: 16MB max     │  │
-│  └────────────────────┬───────────────────────┘  │
-│                       │                          │
-│  ┌────────────────────▼───────────────────────┐  │
-│  │          Capability Provider               │  │
-│  │  "oxide" import module                     │  │
-│  │  canvas, console, storage, clipboard,      │  │
-│  │  fetch, images, crypto, base64, protobuf,  │  │
-│  │  dynamic module loading                    │  │
-│  └────────────────────┬───────────────────────┘  │
-│                       │                          │
-│  ┌────────────────────▼───────────────────────┐  │
-│  │           Guest .wasm Module               │  │
-│  │  exports: start_app()                      │  │
-│  │  imports: oxide::*                         │  │
-│  └────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│                   Oxide Browser                      │
+│  ┌──────────┐  ┌────────────┐  ┌──────────────┐      │
+│  │  URL Bar │  │   Canvas   │  │   Console    │      │
+│  └────┬─────┘  └──────┬─────┘  └──────┬───────┘      │
+│       │               │               │              │
+│  ┌────▼───────────────▼───────────────▼───────┐      │
+│  │              Host Runtime                  │      │
+│  │  wasmtime engine + sandbox policy          │      │
+│  │  fuel limit: 500M  │  memory: 16MB max     │      │
+│  └────────────────────┬───────────────────────┘      │
+│                       │                              │
+│  ┌────────────────────▼───────────────────────┐      │
+│  │          Capability Provider               │      │
+│  │  "oxide" import module                     │      │
+│  │  canvas, console, storage, clipboard,      │      │
+│  │  fetch, audio, video, media capture,       │      │
+│  │  crypto, timers, navigation, widgets,      │      │
+│  │  input, hyperlinks, dynamic loading        │      │
+│  └────────────────────┬───────────────────────┘      │
+│                       │                              │
+│  ┌────────────────────▼───────────────────────┐      │
+│  │           Guest .wasm Module               │      │
+│  │  exports: start_app(), on_frame(dt_ms)     │      │
+│  │  imports: oxide::*                         │      │
+│  └────────────────────────────────────────────┘      │
+└──────────────────────────────────────────────────────┘
 ```
+
+### Rendering Model (GPUI)
+
+Oxide uses an **immediate-mode rendering** approach backed by GPUI:
+
+1. Each frame, the guest issues draw commands (`canvas_clear`, `canvas_rect`, `canvas_text`, …) which push `DrawCommand` variants into the host state.
+2. Widget calls (`ui_button`, `ui_slider`, …) push `WidgetCommand` entries.
+3. The GPUI shell paints both queues each frame using GPU-accelerated primitives: `paint_quad` for rectangles, `paint_path` for circles and lines, `paint_image` for images, and GPU text shaping for text.
+4. Images are decoded once and cached as GPUI `RenderImage` textures (same path for video frames).
+5. Widget interactions (clicks, drags, text edits) flow back through shared state, which the guest reads on the next frame call.
+
+No layout engine. No style cascade. No DOM. The guest decides exactly where every pixel goes.
 
 ---
 
@@ -69,9 +84,9 @@ This opens the Oxide browser window with a URL bar, canvas area, and console pan
 
 ---
 
-## Creating a Guest Application (WASM Website)
+## Creating a Guest Application
 
-Guest applications are Rust libraries compiled to `wasm32-unknown-unknown` that export a single entry point: `start_app()`.
+Guest applications are Rust libraries compiled to `wasm32-unknown-unknown`.
 
 ### Step 1: Create a new project
 
@@ -93,34 +108,73 @@ crate-type = ["cdylib"]
 
 [dependencies]
 oxide-sdk = { path = "../oxide/oxide-sdk" }
-# Or, if published:
-# oxide-sdk = "0.1"
 ```
 
 The `crate-type = ["cdylib"]` is essential — it tells Cargo to produce a `.wasm` file suitable for dynamic loading.
 
 ### Step 3: Write your app
 
+#### Static app (one-shot render)
+
 ```rust
-// src/lib.rs
 use oxide_sdk::*;
 
 #[no_mangle]
 pub extern "C" fn start_app() {
     log("App started!");
-
-    // Clear the canvas with a dark background
     canvas_clear(30, 30, 46, 255);
-
-    // Draw a title
     canvas_text(20.0, 30.0, 28.0, 255, 255, 255, "My Oxide App");
-
-    // Draw some shapes
     canvas_rect(20.0, 80.0, 200.0, 100.0, 80, 120, 200, 255);
     canvas_circle(400.0, 300.0, 60.0, 200, 100, 150, 255);
     canvas_line(20.0, 200.0, 600.0, 200.0, 100, 100, 100, 2.0);
+}
+```
 
-    log("Rendering complete.");
+#### Interactive app (frame loop with widgets)
+
+```rust
+use oxide_sdk::*;
+
+static mut COUNTER: i32 = 0;
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("Interactive app started");
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    canvas_clear(30, 30, 46, 255);
+    canvas_text(20.0, 30.0, 24.0, 255, 255, 255, "Counter App");
+
+    if ui_button(1, 20.0, 70.0, 120.0, 30.0, "Increment") {
+        unsafe { COUNTER += 1; }
+    }
+    if ui_button(2, 150.0, 70.0, 80.0, 30.0, "Reset") {
+        unsafe { COUNTER = 0; }
+    }
+
+    let count = unsafe { COUNTER };
+    canvas_text(20.0, 120.0, 18.0, 160, 220, 160, &format!("Count: {count}"));
+
+    let (mx, my) = mouse_position();
+    canvas_circle(mx, my, 10.0, 255, 100, 100, 180);
+}
+```
+
+#### Using the high-level drawing API
+
+```rust
+use oxide_sdk::draw::*;
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    let c = Canvas::new();
+    c.clear(Color::hex(0x1e1e2e));
+    c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
+    c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::RED);
+    c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
+    c.line(Point2D::ZERO, Point2D::new(400.0, 300.0), 2.0, Color::YELLOW);
 }
 ```
 
@@ -138,292 +192,360 @@ target/wasm32-unknown-unknown/release/my_oxide_app.wasm
 ### Step 5: Run in Oxide
 
 - Open the Oxide browser
-- Click **"Open File"** and select your `.wasm` file, OR
+- Click **"Open"** and select your `.wasm` file, OR
 - Serve it over HTTP and enter the URL in the address bar
 
 ---
 
-## Browser API Reference
+## API Reference
 
 All APIs are available through the `oxide-sdk` crate. Import them with `use oxide_sdk::*;`.
+
+### High-Level Drawing API (`oxide_sdk::draw`)
+
+The `draw` module provides GPUI-inspired ergonomic types that wrap the low-level canvas functions.
+
+#### Types
+
+| Type | Description |
+|------|-------------|
+| `Color` | sRGB + alpha color with named constants and constructors |
+| `Point2D` | 2D point in canvas coordinates |
+| `Rect` | Axis-aligned rectangle (x, y, w, h) with hit-testing |
+| `Canvas` | Zero-cost facade for drawing operations |
+
+#### Color
+
+```rust
+use oxide_sdk::draw::Color;
+
+let c = Color::rgb(255, 128, 0);        // opaque orange
+let c = Color::rgba(255, 128, 0, 128);  // semi-transparent
+let c = Color::hex(0xFF8000);           // from hex
+let c = Color::RED.with_alpha(128);     // modify alpha
+
+// Named constants: WHITE, BLACK, RED, GREEN, BLUE, YELLOW, CYAN, MAGENTA, TRANSPARENT
+```
+
+#### Canvas
+
+```rust
+use oxide_sdk::draw::*;
+
+let c = Canvas::new();
+c.clear(Color::hex(0x1e1e2e));
+c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::BLUE);
+c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::RED);
+c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
+c.line(Point2D::ZERO, Point2D::new(100.0, 100.0), 2.0, Color::YELLOW);
+c.image(Rect::new(0.0, 0.0, 400.0, 300.0), &image_bytes);
+
+let (w, h) = c.dimensions();
+```
+
+### Low-Level Canvas API
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `canvas_clear` | `fn(r, g, b, a: u8)` | Clear canvas with solid RGBA color |
+| `canvas_rect` | `fn(x, y, w, h: f32, r, g, b, a: u8)` | Draw filled rectangle |
+| `canvas_circle` | `fn(cx, cy, radius: f32, r, g, b, a: u8)` | Draw filled circle |
+| `canvas_text` | `fn(x, y, size: f32, r, g, b: u8, text: &str)` | Draw text |
+| `canvas_line` | `fn(x1, y1, x2, y2: f32, r, g, b: u8, thickness: f32)` | Draw a line |
+| `canvas_image` | `fn(x, y, w, h: f32, data: &[u8])` | Draw encoded image (PNG/JPEG/GIF/WebP) |
+| `canvas_dimensions` | `fn() -> (u32, u32)` | Get canvas `(width, height)` in pixels |
+
+```rust
+canvas_clear(30, 30, 46, 255);
+canvas_rect(10.0, 10.0, 100.0, 50.0, 255, 0, 0, 255);
+canvas_circle(200.0, 200.0, 30.0, 0, 255, 0, 255);
+canvas_text(10.0, 80.0, 16.0, 255, 255, 255, "Hello!");
+canvas_line(0.0, 0.0, 100.0, 100.0, 255, 255, 0, 2.0);
+
+let (w, h) = canvas_dimensions();
+```
 
 ### Console
 
 | Function | Signature | Description |
-|---|---|---|
-| `log` | `fn log(msg: &str)` | Print a message to the browser console |
-| `warn` | `fn warn(msg: &str)` | Print a warning (yellow) to the console |
-| `error` | `fn error(msg: &str)` | Print an error (red) to the console |
+|----------|-----------|-------------|
+| `log` | `fn(msg: &str)` | Informational message |
+| `warn` | `fn(msg: &str)` | Warning (yellow) |
+| `error` | `fn(msg: &str)` | Error (red) |
 
-```rust
-log("This is informational");
-warn("This is a warning");
-error("Something went wrong!");
-```
+### Input Polling
 
-### Canvas
-
-The canvas is the main rendering surface. Coordinates start at (0, 0) in the top-left.
+All input functions return per-frame data. Call them from `on_frame()`.
 
 | Function | Signature | Description |
-|---|---|---|
-| `canvas_clear` | `fn canvas_clear(r: u8, g: u8, b: u8, a: u8)` | Clear canvas with solid color |
-| `canvas_rect` | `fn canvas_rect(x, y, w, h: f32, r, g, b, a: u8)` | Draw filled rectangle |
-| `canvas_circle` | `fn canvas_circle(cx, cy, radius: f32, r, g, b, a: u8)` | Draw filled circle |
-| `canvas_text` | `fn canvas_text(x, y, size: f32, r, g, b: u8, text: &str)` | Draw text |
-| `canvas_line` | `fn canvas_line(x1, y1, x2, y2: f32, r, g, b: u8, thickness: f32)` | Draw a line |
-| `canvas_dimensions` | `fn canvas_dimensions() -> (u32, u32)` | Get canvas (width, height) |
+|----------|-----------|-------------|
+| `mouse_position` | `fn() -> (f32, f32)` | Mouse `(x, y)` in canvas coordinates |
+| `mouse_button_down` | `fn(button: u32) -> bool` | Button currently held (0=left, 1=right, 2=middle) |
+| `mouse_button_clicked` | `fn(button: u32) -> bool` | Button clicked this frame |
+| `key_down` | `fn(key: u32) -> bool` | Key currently held (see `KEY_*` constants) |
+| `key_pressed` | `fn(key: u32) -> bool` | Key pressed this frame |
+| `scroll_delta` | `fn() -> (f32, f32)` | Scroll wheel `(dx, dy)` this frame |
+| `modifiers` | `fn() -> u32` | Bitmask: bit 0=Shift, 1=Ctrl, 2=Alt |
+| `shift_held` | `fn() -> bool` | Shift modifier |
+| `ctrl_held` | `fn() -> bool` | Ctrl/Cmd modifier |
+| `alt_held` | `fn() -> bool` | Alt modifier |
+
+#### Key Constants
 
 ```rust
-canvas_clear(0, 0, 0, 255);                                // black background
-canvas_rect(10.0, 10.0, 100.0, 50.0, 255, 0, 0, 255);     // red rectangle
-canvas_circle(200.0, 200.0, 30.0, 0, 255, 0, 255);         // green circle
-canvas_text(10.0, 80.0, 16.0, 255, 255, 255, "Hello!");    // white text
-canvas_line(0.0, 0.0, 100.0, 100.0, 255, 255, 0, 2.0);    // yellow diagonal line
-
-let (w, h) = canvas_dimensions();
-log(&format!("Canvas is {}x{}", w, h));
+// Letters: KEY_A (0) through KEY_Z (25)
+// Digits: KEY_0 (26) through KEY_9 (35)
+// Special: KEY_ENTER (36), KEY_ESCAPE (37), KEY_TAB (38), KEY_BACKSPACE (39),
+//          KEY_DELETE (40), KEY_SPACE (41)
+// Arrows: KEY_UP (42), KEY_DOWN (43), KEY_LEFT (44), KEY_RIGHT (45)
+// Navigation: KEY_HOME (46), KEY_END (47), KEY_PAGE_UP (48), KEY_PAGE_DOWN (49)
 ```
 
-### Geolocation
+### Interactive Widgets
+
+Widgets are **immediate-mode**: call them every frame from `on_frame()`. They return the current value. The host renders them as native GPUI elements overlaid on the canvas.
 
 | Function | Signature | Description |
-|---|---|---|
-| `get_location` | `fn get_location() -> String` | Returns mock GPS coordinates as `"lat,lon"` |
+|----------|-----------|-------------|
+| `ui_button` | `fn(id, x, y, w, h: f32, label: &str) -> bool` | Button; returns `true` when clicked |
+| `ui_checkbox` | `fn(id, x, y: f32, label: &str, initial: bool) -> bool` | Checkbox; returns checked state |
+| `ui_slider` | `fn(id, x, y, w, min, max, initial: f32) -> f32` | Slider; returns current value |
+| `ui_text_input` | `fn(id, x, y, w: f32, initial: &str) -> String` | Text field; returns current text |
 
 ```rust
-let coords = get_location();  // "37.7749,-122.4194"
-let parts: Vec<&str> = coords.split(',').collect();
-let lat = parts[0];
-let lon = parts[1];
-```
-
-> **Note:** This returns mock data in the PoC. A production version would request real GPS permission.
-
-### File Upload
-
-| Function | Signature | Description |
-|---|---|---|
-| `upload_file` | `fn upload_file() -> Option<UploadedFile>` | Opens native file picker, returns file content |
-
-The `UploadedFile` struct:
-```rust
-pub struct UploadedFile {
-    pub name: String,      // filename
-    pub data: Vec<u8>,     // raw file bytes (max 1MB)
+if ui_button(1, 20.0, 100.0, 120.0, 28.0, "Click Me!") {
+    log("Button was clicked!");
 }
-```
 
-```rust
-if let Some(file) = upload_file() {
-    log(&format!("Selected: {} ({} bytes)", file.name, file.data.len()));
-}
-```
-
-### Local Storage
-
-Key-value storage scoped to the current session. Data does not persist across browser restarts in the PoC.
-
-| Function | Signature | Description |
-|---|---|---|
-| `storage_set` | `fn storage_set(key: &str, value: &str)` | Store a value |
-| `storage_get` | `fn storage_get(key: &str) -> String` | Retrieve a value (empty if missing) |
-| `storage_remove` | `fn storage_remove(key: &str)` | Delete a key |
-
-```rust
-storage_set("username", "alice");
-let name = storage_get("username");  // "alice"
-storage_remove("username");
-let name = storage_get("username");  // ""
-```
-
-### Clipboard
-
-| Function | Signature | Description |
-|---|---|---|
-| `clipboard_write` | `fn clipboard_write(text: &str)` | Copy text to system clipboard |
-| `clipboard_read` | `fn clipboard_read() -> String` | Read text from system clipboard |
-
-```rust
-clipboard_write("Copied from Oxide!");
-let text = clipboard_read();
-```
-
-### Time
-
-| Function | Signature | Description |
-|---|---|---|
-| `time_now_ms` | `fn time_now_ms() -> u64` | Current time in ms since UNIX epoch |
-
-```rust
-let start = time_now_ms();
-// ... do work ...
-let elapsed = time_now_ms() - start;
-log(&format!("Took {}ms", elapsed));
-```
-
-### Random
-
-| Function | Signature | Description |
-|---|---|---|
-| `random_u64` | `fn random_u64() -> u64` | Random 64-bit unsigned integer |
-| `random_f64` | `fn random_f64() -> f64` | Random float in [0.0, 1.0) |
-
-```rust
-let dice = (random_u64() % 6) + 1;
-let probability = random_f64();
-```
-
-### Notifications
-
-| Function | Signature | Description |
-|---|---|---|
-| `notify` | `fn notify(title: &str, body: &str)` | Display a notification in the console |
-
-```rust
-notify("Download Complete", "Your file has been saved.");
+let dark_mode = ui_checkbox(10, 20.0, 140.0, "Dark mode", false);
+let volume = ui_slider(20, 20.0, 180.0, 300.0, 0.0, 100.0, 50.0);
+let name = ui_text_input(30, 20.0, 220.0, 300.0, "");
 ```
 
 ### HTTP Fetch
 
-The fetch API lets guest modules make HTTP requests. The host mediates all network access — the guest never opens raw sockets. **Protocol Buffers is the native data format** — use `fetch_post_proto` for the idiomatic path.
+All network access is mediated by the host — the guest never opens raw sockets.
 
 | Function | Signature | Description |
-|---|---|---|
-| `fetch` | `fn fetch(method, url, content_type, body) -> Result<FetchResponse, i64>` | Full HTTP request |
-| `fetch_get` | `fn fetch_get(url: &str) -> Result<FetchResponse, i64>` | HTTP GET |
-| `fetch_post` | `fn fetch_post(url, content_type, body) -> Result<FetchResponse, i64>` | HTTP POST |
-| `fetch_post_proto` | `fn fetch_post_proto(url, msg: &ProtoEncoder) -> Result<FetchResponse, i64>` | POST with protobuf body |
-| `fetch_put` | `fn fetch_put(url, content_type, body) -> Result<FetchResponse, i64>` | HTTP PUT |
-| `fetch_delete` | `fn fetch_delete(url: &str) -> Result<FetchResponse, i64>` | HTTP DELETE |
-
-The `FetchResponse` struct:
-```rust
-pub struct FetchResponse {
-    pub status: u32,        // HTTP status code
-    pub body: Vec<u8>,      // response body bytes
-}
-impl FetchResponse {
-    pub fn text(&self) -> String;  // body as UTF-8
-}
-```
+|----------|-----------|-------------|
+| `fetch` | `fn(method, url, content_type, body) -> Result<FetchResponse, i64>` | Full HTTP request |
+| `fetch_get` | `fn(url: &str) -> Result<FetchResponse, i64>` | GET shorthand |
+| `fetch_post` | `fn(url, content_type, body) -> Result<FetchResponse, i64>` | POST |
+| `fetch_post_proto` | `fn(url, msg: &ProtoEncoder) -> Result<FetchResponse, i64>` | POST with protobuf |
+| `fetch_put` | `fn(url, content_type, body) -> Result<FetchResponse, i64>` | PUT |
+| `fetch_delete` | `fn(url: &str) -> Result<FetchResponse, i64>` | DELETE |
 
 ```rust
-// Simple GET
 let resp = fetch_get("https://api.example.com/data").unwrap();
 log(&format!("Status: {}, Body: {}", resp.status, resp.text()));
-
-// POST with protobuf (native format)
-use oxide_sdk::proto::ProtoEncoder;
-let msg = ProtoEncoder::new()
-    .string(1, "alice")
-    .uint64(2, 42);
-let resp = fetch_post_proto("https://api.example.com/users", &msg).unwrap();
-
-// POST with JSON
-let json = r#"{"name":"alice"}"#;
-let resp = fetch_post("https://api.example.com/users", "application/json", json.as_bytes()).unwrap();
-```
-
-### Dynamic Module Loading
-
-Guest modules can fetch and execute other `.wasm` modules at runtime — analogous to a `<script src="...">` tag in traditional browsers. The child module shares the same canvas, console, and storage context.
-
-| Function | Signature | Description |
-|---|---|---|
-| `load_module` | `fn load_module(url: &str) -> i32` | Fetch and run another .wasm module (0 = success) |
-
-```rust
-let result = load_module("https://cdn.example.com/widget.wasm");
-if result != 0 {
-    error(&format!("Failed to load module: error code {}", result));
-}
-```
-
-### Canvas Image
-
-Display decoded images (PNG, JPEG, GIF, WebP) on the canvas. Image bytes can come from `fetch`, `upload_file`, or be embedded in the binary.
-
-| Function | Signature | Description |
-|---|---|---|
-| `canvas_image` | `fn canvas_image(x, y, w, h: f32, data: &[u8])` | Draw a decoded image at position/size |
-
-```rust
-// Fetch an image from a URL and display it
-let resp = fetch_get("https://example.com/logo.png").unwrap();
-canvas_image(20.0, 100.0, 200.0, 150.0, &resp.body);
-
-// Display an uploaded file as an image
-if let Some(file) = upload_file() {
-    canvas_image(0.0, 0.0, 400.0, 300.0, &file.data);
-}
 ```
 
 ### Protobuf (Native Data Format)
 
-Oxide uses Protocol Buffers wire format as its native serialisation layer. The `oxide_sdk::proto` module provides a zero-dependency encoder/decoder that produces bytes compatible with any protobuf implementation.
+The `oxide_sdk::proto` module provides a zero-dependency encoder/decoder compatible with the Protocol Buffers wire format.
 
 ```rust
 use oxide_sdk::proto::{ProtoEncoder, ProtoDecoder};
 
-// Encode a message
 let msg = ProtoEncoder::new()
-    .string(1, "alice")           // field 1: string
-    .uint64(2, 42)                // field 2: varint
-    .bool(3, true)                // field 3: bool
-    .double(4, 3.14)              // field 4: double
-    .bytes(5, &[0xCA, 0xFE]);    // field 5: raw bytes
+    .string(1, "alice")
+    .uint64(2, 42)
+    .bool(3, true);
 let data = msg.finish();
 
-// Decode a message
 let mut decoder = ProtoDecoder::new(&data);
 while let Some(field) = decoder.next() {
     match field.number {
-        1 => log(&format!("name  = {}", field.as_str())),
-        2 => log(&format!("age   = {}", field.as_u64())),
-        3 => log(&format!("admin = {}", field.as_bool())),
-        4 => log(&format!("score = {}", field.as_f64())),
-        5 => log(&format!("blob  = {:?}", field.as_bytes())),
+        1 => log(&format!("name = {}", field.as_str())),
+        2 => log(&format!("age  = {}", field.as_u64())),
         _ => {}
     }
 }
-
-// Nested messages
-let address = ProtoEncoder::new()
-    .string(1, "123 Main St")
-    .string(2, "Springfield");
-let user = ProtoEncoder::new()
-    .string(1, "alice")
-    .message(2, &address);   // embed sub-message
 ```
 
-The encoder supports all protobuf wire types: `uint32`, `uint64`, `int32`, `int64`, `sint32`, `sint64`, `bool`, `string`, `bytes`, `float`, `double`, `fixed32`, `fixed64`, `sfixed32`, `sfixed64`, and nested `message`.
+### Storage
 
-### SHA-256 Hashing
+#### Session storage (in-memory, cleared on restart)
 
 | Function | Signature | Description |
-|---|---|---|
-| `hash_sha256` | `fn hash_sha256(data: &[u8]) -> [u8; 32]` | SHA-256 hash (raw bytes) |
-| `hash_sha256_hex` | `fn hash_sha256_hex(data: &[u8]) -> String` | SHA-256 hash (hex string) |
+|----------|-----------|-------------|
+| `storage_set` | `fn(key: &str, value: &str)` | Store a value |
+| `storage_get` | `fn(key: &str) -> String` | Retrieve (empty if missing) |
+| `storage_remove` | `fn(key: &str)` | Delete a key |
 
-```rust
-let hash = hash_sha256(b"hello world");
-let hex = hash_sha256_hex(b"hello world");
-log(&format!("SHA-256: {}", hex));
-```
-
-### Base64
+#### Persistent KV store (on-disk, survives restarts)
 
 | Function | Signature | Description |
-|---|---|---|
-| `base64_encode` | `fn base64_encode(data: &[u8]) -> String` | Encode bytes to base64 |
-| `base64_decode` | `fn base64_decode(encoded: &str) -> Vec<u8>` | Decode base64 to bytes |
+|----------|-----------|-------------|
+| `kv_store_set` | `fn(key: &str, value: &[u8]) -> bool` | Store bytes |
+| `kv_store_set_str` | `fn(key: &str, value: &str) -> bool` | Store string |
+| `kv_store_get` | `fn(key: &str) -> Option<Vec<u8>>` | Read bytes |
+| `kv_store_get_str` | `fn(key: &str) -> Option<String>` | Read string |
+| `kv_store_delete` | `fn(key: &str) -> bool` | Delete key |
+
+### Audio Playback
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `audio_play` | `fn(data: &[u8]) -> i32` | Play from encoded bytes (WAV/MP3/OGG/FLAC) |
+| `audio_play_url` | `fn(url: &str) -> i32` | Fetch and play from URL |
+| `audio_play_with_format` | `fn(data: &[u8], format: AudioFormat) -> i32` | Play with format hint |
+| `audio_detect_format` | `fn(data: &[u8]) -> AudioFormat` | Sniff container from magic bytes |
+| `audio_pause` / `audio_resume` / `audio_stop` | `fn()` | Playback control |
+| `audio_set_volume` / `audio_get_volume` | `fn(f32)` / `fn() -> f32` | Volume (0.0–2.0) |
+| `audio_is_playing` | `fn() -> bool` | Check playback state |
+| `audio_position` / `audio_seek` / `audio_duration` | | Seek and position (ms) |
+| `audio_set_loop` | `fn(enabled: bool)` | Enable/disable looping |
+| `audio_channel_play` | `fn(channel: u32, data: &[u8]) -> i32` | Multi-channel playback |
+| `audio_channel_stop` | `fn(channel: u32)` | Stop a channel |
+| `audio_channel_set_volume` | `fn(channel: u32, level: f32)` | Per-channel volume |
 
 ```rust
-let encoded = base64_encode(b"Hello, Oxide!");
-let decoded = base64_decode(&encoded);
-assert_eq!(decoded, b"Hello, Oxide!");
+// Play from URL
+audio_play_url("https://example.com/song.mp3");
+
+// Multi-channel (music + effects)
+audio_channel_play(0, &music_bytes);   // background music
+audio_channel_play(1, &sfx_bytes);     // sound effect
+audio_channel_set_volume(0, 0.5);      // lower music volume
 ```
+
+### Video Playback
+
+Requires FFmpeg on the host for decoding.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `video_load` | `fn(data: &[u8]) -> i32` | Load from encoded bytes |
+| `video_load_url` | `fn(url: &str) -> i32` | Load from URL (progressive or HLS) |
+| `video_play` / `video_pause` / `video_stop` | `fn()` | Playback control |
+| `video_render` | `fn(x, y, w, h: f32) -> i32` | Draw current frame to canvas |
+| `video_seek` | `fn(position_ms: u64) -> i32` | Seek to position |
+| `video_position` / `video_duration` | `fn() -> u64` | Position and duration (ms) |
+| `video_set_volume` / `video_get_volume` | `fn(f32)` / `fn() -> f32` | Volume control |
+| `video_set_loop` | `fn(enabled: bool)` | Enable looping |
+| `video_set_pip` | `fn(enabled: bool)` | Picture-in-picture overlay |
+| `video_hls_variant_count` / `video_hls_open_variant` | | HLS adaptive streaming |
+| `subtitle_load_srt` / `subtitle_load_vtt` | `fn(text: &str) -> i32` | Load subtitles |
+| `subtitle_clear` | `fn()` | Remove subtitles |
+
+```rust
+video_load_url("https://example.com/video.mp4");
+video_play();
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let (w, h) = canvas_dimensions();
+    video_render(0.0, 0.0, w as f32, h as f32);
+}
+```
+
+### Media Capture
+
+Permission dialogs are shown by the host before granting access.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `camera_open` | `fn() -> i32` | Open default camera (0=success) |
+| `camera_close` | `fn()` | Stop camera |
+| `camera_capture_frame` | `fn(out: &mut [u8]) -> u32` | Capture RGBA8 frame |
+| `camera_frame_dimensions` | `fn() -> (u32, u32)` | Frame size in pixels |
+| `microphone_open` | `fn() -> i32` | Start mic capture (0=success) |
+| `microphone_close` | `fn()` | Stop mic |
+| `microphone_sample_rate` | `fn() -> u32` | Sample rate in Hz |
+| `microphone_read_samples` | `fn(out: &mut [f32]) -> u32` | Read mono f32 samples |
+| `screen_capture` | `fn(out: &mut [u8]) -> Result<usize, i32>` | Screenshot as RGBA8 |
+| `screen_capture_dimensions` | `fn() -> (u32, u32)` | Screenshot dimensions |
+| `media_pipeline_stats` | `fn() -> (u64, u32)` | Camera frames / mic depth |
+
+```rust
+if camera_open() == 0 {
+    let mut buf = vec![0u8; 1920 * 1080 * 4];
+    let bytes = camera_capture_frame(&mut buf);
+    let (w, h) = camera_frame_dimensions();
+    log(&format!("Captured {}x{} frame ({} bytes)", w, h, bytes));
+}
+```
+
+### Timers
+
+Timer callbacks fire via the guest-exported `on_timer(callback_id)` function.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `set_timeout` | `fn(callback_id: u32, delay_ms: u32) -> u32` | One-shot timer |
+| `set_interval` | `fn(callback_id: u32, interval_ms: u32) -> u32` | Repeating timer |
+| `clear_timer` | `fn(timer_id: u32)` | Cancel a timer |
+| `time_now_ms` | `fn() -> u64` | Current UNIX timestamp in ms |
+
+```rust
+let timer = set_timeout(42, 1000); // fires on_timer(42) after 1 second
+
+#[no_mangle]
+pub extern "C" fn on_timer(callback_id: u32) {
+    if callback_id == 42 {
+        log("Timer fired!");
+    }
+}
+```
+
+### Navigation & History
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `navigate` | `fn(url: &str) -> i32` | Navigate to a URL |
+| `push_state` | `fn(state: &[u8], title: &str, url: &str)` | Push history entry |
+| `replace_state` | `fn(state: &[u8], title: &str, url: &str)` | Replace current entry |
+| `get_url` | `fn() -> String` | Current page URL |
+| `get_state` | `fn() -> Option<Vec<u8>>` | Current history state bytes |
+| `history_length` | `fn() -> u32` | Number of history entries |
+| `history_back` / `history_forward` | `fn() -> bool` | Navigate history |
+
+### Hyperlinks
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `register_hyperlink` | `fn(x, y, w, h: f32, url: &str) -> i32` | Register clickable region |
+| `clear_hyperlinks` | `fn()` | Remove all hyperlinks |
+
+```rust
+canvas_text(20.0, 100.0, 16.0, 100, 150, 255, "Visit Example");
+register_hyperlink(20.0, 100.0, 200.0, 20.0, "https://example.com/app.wasm");
+```
+
+### Crypto & Encoding
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `hash_sha256` | `fn(data: &[u8]) -> [u8; 32]` | SHA-256 hash (raw) |
+| `hash_sha256_hex` | `fn(data: &[u8]) -> String` | SHA-256 hash (hex) |
+| `base64_encode` | `fn(data: &[u8]) -> String` | Encode to base64 |
+| `base64_decode` | `fn(encoded: &str) -> Vec<u8>` | Decode from base64 |
+
+### Clipboard
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `clipboard_write` | `fn(text: &str)` | Copy to clipboard |
+| `clipboard_read` | `fn() -> String` | Read from clipboard |
+
+### Random
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `random_u64` | `fn() -> u64` | Cryptographic random u64 |
+| `random_f64` | `fn() -> f64` | Random float in [0.0, 1.0) |
+
+### Other
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `notify` | `fn(title: &str, body: &str)` | Show a notification |
+| `upload_file` | `fn() -> Option<UploadedFile>` | Open native file picker |
+| `get_location` | `fn() -> String` | Mock geolocation as `"lat,lon"` |
+| `load_module` | `fn(url: &str) -> i32` | Dynamically load another `.wasm` |
+| `url_resolve` | `fn(base: &str, rel: &str) -> Option<String>` | Resolve relative URL |
+| `url_encode` / `url_decode` | `fn(input: &str) -> String` | Percent-encoding |
 
 ---
 
@@ -431,14 +553,12 @@ assert_eq!(decoded, b"Hello, Oxide!");
 
 ### Sandbox Guarantees
 
-Every guest `.wasm` module runs under strict constraints:
-
 | Constraint | Value | Purpose |
-|---|---|---|
+|------------|-------|---------|
 | **Filesystem access** | None | Guest cannot read/write host files |
 | **Environment variables** | None | Guest cannot read host env vars |
 | **Network sockets** | None | Guest cannot open arbitrary connections |
-| **Memory limit** | 16 MB (256 pages) | Prevents memory exhaustion attacks |
+| **Memory limit** | 16 MB (256 pages) | Prevents memory exhaustion |
 | **Fuel limit** | 500M instructions | Prevents infinite loops / DoS |
 
 ### How it works
@@ -450,11 +570,41 @@ Every guest `.wasm` module runs under strict constraints:
 
 ### Mediated I/O
 
-Several APIs grant controlled access to external resources while maintaining the sandbox:
+- **File upload**: `upload_file()` opens a native OS file picker. The guest never gets filesystem access; the host passes the selected file's name and content bytes.
+- **HTTP fetch**: `fetch()` proxies through the host. The guest cannot open raw sockets.
+- **Dynamic loading**: `load_module()` fetches and runs a child `.wasm` with isolated memory and fuel, preventing sandbox escape.
 
-- **File upload**: `upload_file()` opens a native OS file picker. The guest never gets filesystem access; the *host* mediates the interaction and only passes the selected file's name and content bytes.
-- **HTTP fetch**: `fetch()` lets the guest make HTTP requests, but all network access is proxied through the host. The guest cannot open raw sockets. The host can enforce allowlists, rate limits, or other policies.
-- **Dynamic loading**: `load_module()` fetches and runs another `.wasm` module. The child inherits the same canvas/console/storage but gets its own memory and fuel budget, preventing escape from the sandbox.
+---
+
+## Guest Module Contract
+
+Every `.wasm` module loaded by Oxide must:
+
+1. **Export `start_app`** — `extern "C" fn()` entry point, called once on load.
+2. **Optionally export `on_frame`** — `extern "C" fn(dt_ms: u32)` for interactive apps with a render loop.
+3. **Optionally export `on_timer`** — `extern "C" fn(callback_id: u32)` to receive timer callbacks.
+4. **Import from `"oxide"` module** — All host capabilities are under this namespace.
+5. **Compile as `cdylib`** — `crate-type = ["cdylib"]` in `Cargo.toml`.
+6. **Target `wasm32-unknown-unknown`** — no WASI, pure capability-based I/O.
+
+### Minimal valid guest (without the SDK)
+
+```rust
+#[link(wasm_import_module = "oxide")]
+extern "C" {
+    fn api_log(ptr: u32, len: u32);
+    fn api_canvas_clear(r: u32, g: u32, b: u32, a: u32);
+}
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    let msg = "Hello from raw WASM!";
+    unsafe {
+        api_log(msg.as_ptr() as u32, msg.len() as u32);
+        api_canvas_clear(20, 20, 40, 255);
+    }
+}
+```
 
 ---
 
@@ -464,60 +614,38 @@ Several APIs grant controlled access to external resources while maintaining the
 oxide/
 ├── Cargo.toml                    # Workspace root
 ├── DOCS.md                       # This file
-├── oxide-browser/                # The host browser application
+├── oxide-browser/                # Host browser application
 │   ├── Cargo.toml
 │   └── src/
-│       ├── main.rs               # Entry point, sets up GUI
+│       ├── main.rs               # Entry point (BrowserHost + run_browser)
 │       ├── engine.rs             # WasmEngine, SandboxPolicy, fuel/memory
-│       ├── runtime.rs            # BrowserHost, fetch_and_run, module execution
-│       ├── capabilities.rs       # Host functions (the "oxide" import module)
-│       └── ui.rs                 # egui-based UI (URL bar, canvas, console)
-├── oxide-sdk/                    # Guest SDK
+│       ├── runtime.rs            # BrowserHost, fetch_and_run, module lifecycle
+│       ├── capabilities.rs       # ~100 host functions ("oxide" import module)
+│       ├── ui.rs                 # GPUI shell (toolbar, canvas, console, tabs)
+│       ├── navigation.rs         # History stack with back/forward
+│       ├── bookmarks.rs          # Persistent bookmarks (sled)
+│       ├── url.rs                # WHATWG URL parsing
+│       ├── audio_format.rs       # Audio magic-byte sniffing
+│       ├── video.rs              # FFmpeg video pipeline
+│       ├── video_format.rs       # Video format sniffing
+│       ├── subtitle.rs           # SRT/VTT subtitle parsing
+│       └── media_capture.rs      # Camera, mic, screen capture
+├── oxide-sdk/                    # Guest SDK (no dependencies)
 │   ├── Cargo.toml
 │   └── src/
-│       ├── lib.rs                # Safe wrappers around host FFI imports
-│       └── proto.rs              # Protobuf wire-format encoder/decoder
+│       ├── lib.rs                # Safe wrappers over host FFI imports
+│       ├── draw.rs               # High-level drawing API (Color, Rect, Canvas)
+│       └── proto.rs              # Zero-dependency protobuf codec
+├── oxide-docs/                   # Rustdoc hub crate
 └── examples/
-    └── hello-oxide/              # Example guest application
-        ├── Cargo.toml
-        └── src/
-            └── lib.rs
+    ├── hello-oxide/              # Interactive widget demo
+    ├── audio-player/             # Audio playback example
+    ├── video-player/             # Video playback example
+    ├── timer-demo/               # Timer callbacks
+    ├── media-capture/            # Camera/mic/screen capture
+    ├── index/                    # Demo hub (links to other examples)
+    └── fullstack-notes/          # Full-stack example (Rust frontend + backend)
 ```
-
----
-
-## Building the Example Guest App
-
-```bash
-# From the workspace root
-cargo build --target wasm32-unknown-unknown --release -p hello-oxide
-
-# The output .wasm file:
-ls target/wasm32-unknown-unknown/release/hello_oxide.wasm
-```
-
-Then open it in the browser:
-```bash
-cargo run -p oxide-browser
-# Click "Open File" → select hello_oxide.wasm
-```
-
----
-
-## Serving WASM Files Over HTTP
-
-To test URL-based loading, serve your `.wasm` file over HTTP:
-
-```bash
-# Using Python's built-in server
-cd target/wasm32-unknown-unknown/release/
-python3 -m http.server 8080
-
-# Then in Oxide, navigate to:
-# http://localhost:8080/hello_oxide.wasm
-```
-
-Or use any static file server (nginx, caddy, etc.).
 
 ---
 
@@ -527,9 +655,9 @@ Or use any static file server (nginx, caddy, etc.).
 
 1. **Define it in `capabilities.rs`**: Add a `linker.func_wrap(...)` call in `register_host_functions`.
 2. **Add the FFI declaration in `oxide-sdk/src/lib.rs`**: Add the raw `extern "C"` import and a safe wrapper function.
-3. **Document it**: Update this file with the new API.
+3. **Document it**: Update this file and the rustdoc comments.
 
-### Example: Adding a `api_set_title` capability
+### Example: Adding `api_set_title`
 
 In `capabilities.rs`:
 ```rust
@@ -538,8 +666,7 @@ linker.func_wrap(
     "api_set_title",
     |caller: Caller<'_, HostState>, ptr: u32, len: u32| {
         let mem = caller.data().memory.expect("memory not set");
-        let title = read_guest_string(&mem, &caller, ptr, len)
-            .unwrap_or_default();
+        let title = read_guest_string(&mem, &caller, ptr, len).unwrap_or_default();
         // Store the title somewhere accessible to the UI...
     },
 )?;
@@ -560,38 +687,12 @@ pub fn set_title(title: &str) {
 
 ---
 
-## Guest Module Contract
+## Serving WASM Files Over HTTP
 
-Every `.wasm` module loaded by Oxide must satisfy:
-
-1. **Export `start_app`**: A function with signature `extern "C" fn()`. This is the entry point called by the browser.
-2. **Import from `"oxide"` module**: All host capabilities are provided under the `"oxide"` import namespace.
-3. **Use host-provided memory**: The browser provides a `Memory` export under `oxide::memory`. The SDK handles this transparently.
-
-### Minimal valid guest (without the SDK)
-
-If you don't want to use the SDK, you can write raw imports:
-
-```rust
-#[link(wasm_import_module = "oxide")]
-extern "C" {
-    fn api_log(ptr: u32, len: u32);
-    fn api_canvas_clear(r: u32, g: u32, b: u32, a: u32);
-}
-
-#[no_mangle]
-pub extern "C" fn start_app() {
-    let msg = "Hello from raw WASM!";
-    unsafe {
-        api_log(msg.as_ptr() as u32, msg.len() as u32);
-        api_canvas_clear(20, 20, 40, 255);
-    }
-}
-```
-
-Compile with:
 ```bash
-cargo build --target wasm32-unknown-unknown --release
+cd target/wasm32-unknown-unknown/release/
+python3 -m http.server 8080
+# Navigate to: http://localhost:8080/my_oxide_app.wasm
 ```
 
 ---
@@ -599,10 +700,12 @@ cargo build --target wasm32-unknown-unknown --release
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
-|---|---|---|
+|---------|-------|-----|
 | "module must export `start_app`" | Missing entry point | Add `#[no_mangle] pub extern "C" fn start_app()` |
-| "fuel limit exceeded" | Infinite loop or very long computation | Optimize your code or reduce work per frame |
-| "failed to compile wasm module" | Invalid `.wasm` binary | Ensure you compiled with `--target wasm32-unknown-unknown` |
-| "guest string out of bounds" | Buffer too small for host data | Increase buffer sizes in your guest code |
-| "network request failed" | URL unreachable or CORS | Ensure the server is running and accessible |
-| Blank canvas | No draw commands issued | Call `canvas_clear()` and draw something in `start_app()` |
+| "fuel limit exceeded" | Infinite loop or very long computation | Optimize code or reduce work per frame |
+| "failed to compile wasm module" | Invalid `.wasm` binary | Ensure `--target wasm32-unknown-unknown` |
+| "guest string out of bounds" | Buffer too small | Increase buffer sizes in guest code |
+| "network request failed" | URL unreachable | Ensure the server is running and accessible |
+| Blank canvas | No draw commands | Call `canvas_clear()` + draw something |
+| `canvas_dimensions()` returns (0,0) | Called before first frame | Call from `on_frame()` after the canvas is laid out |
+| `shift_held()` always false | Modifier not synced | Ensure you're on oxide-browser ≥ 0.4.0 |

--- a/DOCS.md
+++ b/DOCS.md
@@ -123,10 +123,10 @@ use oxide_sdk::*;
 pub extern "C" fn start_app() {
     log("App started!");
     canvas_clear(30, 30, 46, 255);
-    canvas_text(20.0, 30.0, 28.0, 255, 255, 255, "My Oxide App");
+    canvas_text(20.0, 30.0, 28.0, 255, 255, 255, 255, "My Oxide App");
     canvas_rect(20.0, 80.0, 200.0, 100.0, 80, 120, 200, 255);
     canvas_circle(400.0, 300.0, 60.0, 200, 100, 150, 255);
-    canvas_line(20.0, 200.0, 600.0, 200.0, 100, 100, 100, 2.0);
+    canvas_line(20.0, 200.0, 600.0, 200.0, 100, 100, 100, 255, 2.0);
 }
 ```
 
@@ -145,7 +145,7 @@ pub extern "C" fn start_app() {
 #[no_mangle]
 pub extern "C" fn on_frame(_dt_ms: u32) {
     canvas_clear(30, 30, 46, 255);
-    canvas_text(20.0, 30.0, 24.0, 255, 255, 255, "Counter App");
+    canvas_text(20.0, 30.0, 24.0, 255, 255, 255, 255, "Counter App");
 
     if ui_button(1, 20.0, 70.0, 120.0, 30.0, "Increment") {
         unsafe { COUNTER += 1; }
@@ -155,7 +155,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
     }
 
     let count = unsafe { COUNTER };
-    canvas_text(20.0, 120.0, 18.0, 160, 220, 160, &format!("Count: {count}"));
+    canvas_text(20.0, 120.0, 18.0, 160, 220, 160, 255, &format!("Count: {count}"));
 
     let (mx, my) = mouse_position();
     canvas_circle(mx, my, 10.0, 255, 100, 100, 180);
@@ -250,8 +250,8 @@ let (w, h) = c.dimensions();
 | `canvas_clear` | `fn(r, g, b, a: u8)` | Clear canvas with solid RGBA color |
 | `canvas_rect` | `fn(x, y, w, h: f32, r, g, b, a: u8)` | Draw filled rectangle |
 | `canvas_circle` | `fn(cx, cy, radius: f32, r, g, b, a: u8)` | Draw filled circle |
-| `canvas_text` | `fn(x, y, size: f32, r, g, b: u8, text: &str)` | Draw text |
-| `canvas_line` | `fn(x1, y1, x2, y2: f32, r, g, b: u8, thickness: f32)` | Draw a line |
+| `canvas_text` | `fn(x, y, size: f32, r, g, b, a: u8, text: &str)` | Draw text |
+| `canvas_line` | `fn(x1, y1, x2, y2: f32, r, g, b, a: u8, thickness: f32)` | Draw a line |
 | `canvas_image` | `fn(x, y, w, h: f32, data: &[u8])` | Draw encoded image (PNG/JPEG/GIF/WebP) |
 | `canvas_dimensions` | `fn() -> (u32, u32)` | Get canvas `(width, height)` in pixels |
 
@@ -259,8 +259,8 @@ let (w, h) = c.dimensions();
 canvas_clear(30, 30, 46, 255);
 canvas_rect(10.0, 10.0, 100.0, 50.0, 255, 0, 0, 255);
 canvas_circle(200.0, 200.0, 30.0, 0, 255, 0, 255);
-canvas_text(10.0, 80.0, 16.0, 255, 255, 255, "Hello!");
-canvas_line(0.0, 0.0, 100.0, 100.0, 255, 255, 0, 2.0);
+canvas_text(10.0, 80.0, 16.0, 255, 255, 255, 255, "Hello!");
+canvas_line(0.0, 0.0, 100.0, 100.0, 255, 255, 0, 255, 2.0);
 
 let (w, h) = canvas_dimensions();
 ```
@@ -509,7 +509,7 @@ pub extern "C" fn on_timer(callback_id: u32) {
 | `clear_hyperlinks` | `fn()` | Remove all hyperlinks |
 
 ```rust
-canvas_text(20.0, 100.0, 16.0, 100, 150, 255, "Visit Example");
+canvas_text(20.0, 100.0, 16.0, 100, 150, 255, 255, "Visit Example");
 register_hyperlink(20.0, 100.0, 200.0, 20.0, "https://example.com/app.wasm");
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo run -p oxide-browser
 # Build the example guest app
 cargo build --target wasm32-unknown-unknown --release -p hello-oxide
 
-# In the browser, click "Open File" and select:
+# In the browser, click "Open" and select:
 # target/wasm32-unknown-unknown/release/hello_oxide.wasm
 ```
 
@@ -40,7 +40,7 @@ cargo build --target wasm32-unknown-unknown --release -p hello-oxide
 │                               │                                  │
 │  ┌────────────────────────────▼───────────────────────────────┐  │
 │  │                  Capability Layer                          │  │
-│  │  "oxide" import module — ~50 host functions                │  │
+│  │  "oxide" import module — ~100 host functions                │  │
 │  │  canvas · console · storage · clipboard · fetch · crypto   │  │
 │  │  input · widgets · navigation · dynamic module loading     │  │
 │  └────────────────────────────┬───────────────────────────────┘  │
@@ -62,7 +62,7 @@ oxide/
 │       ├── main.rs          # GPUI entry — BrowserHost + run_browser
 │       ├── engine.rs        # WasmEngine, SandboxPolicy, compile & memory bounds
 │       ├── runtime.rs       # BrowserHost, fetch/load/instantiate pipeline
-│       ├── capabilities.rs  # ~50 host functions registered into the wasmtime Linker
+│       ├── capabilities.rs  # ~100 host functions registered into the wasmtime Linker
 │       ├── navigation.rs    # History stack, back/forward, push/replace state
 │       ├── url.rs           # WHATWG-style URL parser (http, https, file, oxide schemes)
 │       └── ui.rs            # GPUI shell — toolbar, canvas paint, console, widgets

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ cargo build --target wasm32-unknown-unknown --release -p hello-oxide
 oxide/
 ├── oxide-browser/           # Host browser application
 │   └── src/
-│       ├── main.rs          # eframe bootstrap
+│       ├── main.rs          # GPUI entry — BrowserHost + run_browser
 │       ├── engine.rs        # WasmEngine, SandboxPolicy, compile & memory bounds
 │       ├── runtime.rs       # BrowserHost, fetch/load/instantiate pipeline
 │       ├── capabilities.rs  # ~50 host functions registered into the wasmtime Linker
 │       ├── navigation.rs    # History stack, back/forward, push/replace state
 │       ├── url.rs           # WHATWG-style URL parser (http, https, file, oxide schemes)
-│       └── ui.rs            # egui UI — toolbar, canvas painter, console, widget renderer
+│       └── ui.rs            # GPUI shell — toolbar, canvas paint, console, widgets
 ├── oxide-sdk/               # Guest-side SDK (no dependencies, pure FFI wrappers)
 │   └── src/
 │       ├── lib.rs           # Safe Rust wrappers over host imports
@@ -126,8 +126,8 @@ Oxide uses an **immediate-mode rendering** approach — there is no retained sce
 
 1. Each frame, the guest issues draw commands (`canvas_clear`, `canvas_rect`, `canvas_text`, …) which push `DrawCommand` variants into `HostState.canvas.commands`.
 2. Widget calls (`ui_button`, `ui_slider`, …) push `WidgetCommand` entries.
-3. The egui `CentralPanel` in `ui.rs` drains both queues and paints them using egui primitives (`painter.rect_filled`, `painter.text`, etc.) on an 800×600 canvas.
-4. Images are decoded once and cached as egui textures.
+3. `ui.rs` drains both queues each frame and paints them with GPUI (`paint_quad`, `paint_path`, `paint_image`, text shaping) inside the canvas region.
+4. Images are decoded once and cached as GPUI [`RenderImage`](https://docs.rs/gpui) textures (same path for video frames).
 5. Widget interactions (clicks, drags, text edits) flow back through `widget_states` and `widget_clicked`, which the guest reads on the next frame call.
 
 No layout engine. No style cascade. The guest decides exactly where every pixel goes.
@@ -151,7 +151,7 @@ Security is **additive, not subtractive**: there is nothing to claw back because
 | Runtime     | `wasmtime` | WASM execution with fuel metering and memory limits |
 | Networking  | `reqwest`  | Fetch `.wasm` binaries from URLs |
 | Async       | `tokio`    | Async runtime for network operations |
-| UI          | `egui` / `eframe` | URL bar, canvas renderer, console panel |
+| UI          | [GPUI](https://www.gpui.rs/) | GPU-accelerated window; URL bar, canvas, console |
 | Storage     | `sled`     | Persistent key-value store (per-origin) |
 | File Picker | `rfd`      | Native OS file dialogs |
 | Clipboard   | `arboard`  | System clipboard access |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,7 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 
 ### 2D Acceleration
 
-- [ ] GPU-backed canvas renderer (replace CPU-painted egui primitives)
+- [x] GPUI desktop shell — draw commands rasterized via GPUI; images and video frames as GPU textures
 - [ ] `canvas_rounded_rect()`, `canvas_arc()`, `canvas_bezier()` — extended shape primitives
 - [ ] `canvas_gradient(type, stops)` — linear and radial gradients
 - [ ] `canvas_transform(matrix)` — 2D affine transformations (translate, rotate, scale, skew)
@@ -373,8 +373,8 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 - [ ] macOS (shipped)
 - [ ] Linux (shipped)
 - [ ] Windows (shipped)
-- [ ] Android (via native Rust + egui)
-- [ ] iOS (via native Rust + egui)
+- [ ] Android (native Rust + platform or embedded UI toolkit)
+- [ ] iOS (native Rust + platform or embedded UI toolkit)
 - [ ] Web version (Oxide running inside a traditional browser via wasm-bindgen)
 
 ---

--- a/examples/audio-player/src/lib.rs
+++ b/examples/audio-player/src/lib.rs
@@ -268,7 +268,16 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         ("Stopped", RED)
     };
 
-    canvas_text(20.0, 558.0, 14.0, color.0, color.1, color.2, 255, status_text);
+    canvas_text(
+        20.0,
+        558.0,
+        14.0,
+        color.0,
+        color.1,
+        color.2,
+        255,
+        status_text,
+    );
 
     let note = unsafe { LAST_NOTE };
     if !note.is_empty() {
@@ -294,7 +303,9 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
     );
 
     if looping {
-        canvas_text(250.0, 580.0, 13.0, ORANGE.0, ORANGE.1, ORANGE.2, 255, "LOOP");
+        canvas_text(
+            250.0, 580.0, 13.0, ORANGE.0, ORANGE.1, ORANGE.2, 255, "LOOP",
+        );
     }
 
     // ── Visualiser bar ──────────────────────────────────────────────

--- a/examples/audio-player/src/lib.rs
+++ b/examples/audio-player/src/lib.rs
@@ -52,7 +52,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     // ── Header ──────────────────────────────────────────────────────
     canvas_rect(0.0, 0.0, w, 52.0, ACCENT.0, ACCENT.1, ACCENT.2, 255);
-    canvas_text(20.0, 14.0, 22.0, 255, 255, 255, "Oxide Audio Player");
+    canvas_text(20.0, 14.0, 22.0, 255, 255, 255, 255, "Oxide Audio Player");
 
     // ── Tone Pads ───────────────────────────────────────────────────
     canvas_text(
@@ -62,6 +62,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "TONE PADS",
     );
 
@@ -94,6 +95,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "CUSTOM TONE",
     );
 
@@ -104,6 +106,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "Frequency (Hz)",
     );
     let freq = ui_slider(WIDGET_FREQ, 140.0, 178.0, 250.0, 100.0, 2000.0, 440.0);
@@ -114,6 +117,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         GREEN.0,
         GREEN.1,
         GREEN.2,
+        255,
         &format!("{freq:.0} Hz"),
     );
 
@@ -124,6 +128,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "Duration (sec)",
     );
     let dur = ui_slider(WIDGET_DUR, 140.0, 208.0, 250.0, 0.1, 5.0, 1.0);
@@ -134,6 +139,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         GREEN.0,
         GREEN.1,
         GREEN.2,
+        255,
         &format!("{dur:.1} s"),
     );
 
@@ -153,6 +159,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "PLAY FROM URL",
     );
 
@@ -165,10 +172,10 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
     }
 
     // ── Playback Controls ───────────────────────────────────────────
-    canvas_line(20.0, 355.0, w - 20.0, 355.0, 50, 45, 70, 1.0);
+    canvas_line(20.0, 355.0, w - 20.0, 355.0, 50, 45, 70, 255, 1.0);
 
     canvas_text(
-        20.0, 370.0, 14.0, TEXT_DIM.0, TEXT_DIM.1, TEXT_DIM.2, "CONTROLS",
+        20.0, 370.0, 14.0, TEXT_DIM.0, TEXT_DIM.1, TEXT_DIM.2, 255, "CONTROLS",
     );
 
     if ui_button(BTN_PAUSE, 20.0, 393.0, 80.0, 30.0, "Pause") {
@@ -188,6 +195,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "Volume",
     );
     let vol = ui_slider(WIDGET_VOL, 80.0, 438.0, 250.0, 0.0, 1.5, 1.0);
@@ -199,11 +207,12 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         GREEN.0,
         GREEN.1,
         GREEN.2,
+        255,
         &format!("{:.0}%", vol * 100.0),
     );
 
     // ── SFX Channel ─────────────────────────────────────────────────
-    canvas_line(20.0, 468.0, w - 20.0, 468.0, 50, 45, 70, 1.0);
+    canvas_line(20.0, 468.0, w - 20.0, 468.0, 50, 45, 70, 255, 1.0);
 
     canvas_text(
         20.0,
@@ -212,6 +221,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "SFX CHANNEL (plays over main audio)",
     );
 
@@ -235,13 +245,14 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "SFX Vol",
     );
     let sfx_vol = ui_slider(WIDGET_SFX_VOL, 365.0, 506.0, 100.0, 0.0, 1.5, 0.8);
     audio_channel_set_volume(SFX_CHANNEL, sfx_vol);
 
     // ── Status ──────────────────────────────────────────────────────
-    canvas_line(20.0, 545.0, w - 20.0, 545.0, 50, 45, 70, 1.0);
+    canvas_line(20.0, 545.0, w - 20.0, 545.0, 50, 45, 70, 255, 1.0);
 
     let playing = audio_is_playing();
     let pos_ms = audio_position();
@@ -257,7 +268,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         ("Stopped", RED)
     };
 
-    canvas_text(20.0, 558.0, 14.0, color.0, color.1, color.2, status_text);
+    canvas_text(20.0, 558.0, 14.0, color.0, color.1, color.2, 255, status_text);
 
     let note = unsafe { LAST_NOTE };
     if !note.is_empty() {
@@ -268,6 +279,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             TEXT_DIM.0,
             TEXT_DIM.1,
             TEXT_DIM.2,
+            255,
             &format!("  {note}"),
         );
     }
@@ -278,11 +290,11 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         format!("Position: {pos_secs:.1}s")
     };
     canvas_text(
-        20.0, 580.0, 13.0, TEXT_DIM.0, TEXT_DIM.1, TEXT_DIM.2, &time_info,
+        20.0, 580.0, 13.0, TEXT_DIM.0, TEXT_DIM.1, TEXT_DIM.2, 255, &time_info,
     );
 
     if looping {
-        canvas_text(250.0, 580.0, 13.0, ORANGE.0, ORANGE.1, ORANGE.2, "LOOP");
+        canvas_text(250.0, 580.0, 13.0, ORANGE.0, ORANGE.1, ORANGE.2, 255, "LOOP");
     }
 
     // ── Visualiser bar ──────────────────────────────────────────────

--- a/examples/fullstack-notes/frontend/src/lib.rs
+++ b/examples/fullstack-notes/frontend/src/lib.rs
@@ -392,7 +392,16 @@ fn render_offline(w: f32, err_code: i64) {
     canvas_clear(BG.0, BG.1, BG.2, 255);
     canvas_rect(0.0, 0.0, w, 50.0, TITLE_BG.0, TITLE_BG.1, TITLE_BG.2, 255);
     canvas_text(20.0, 14.0, 22.0, 220, 200, 255, 255, "Oxide Notes");
-    canvas_text(20.0, 38.0, 12.0, DIM.0, DIM.1, DIM.2, 255, "Full-stack demo");
+    canvas_text(
+        20.0,
+        38.0,
+        12.0,
+        DIM.0,
+        DIM.1,
+        DIM.2,
+        255,
+        "Full-stack demo",
+    );
 
     draw_text(
         20.0,

--- a/examples/fullstack-notes/frontend/src/lib.rs
+++ b/examples/fullstack-notes/frontend/src/lib.rs
@@ -99,11 +99,11 @@ fn draw_section_bg(y: f32, h: f32, w: f32) {
 }
 
 fn draw_heading(x: f32, y: f32, label: &str) {
-    canvas_text(x, y, 16.0, HEADING.0, HEADING.1, HEADING.2, label);
+    canvas_text(x, y, 16.0, HEADING.0, HEADING.1, HEADING.2, 255, label);
 }
 
 fn draw_text(x: f32, y: f32, c: (u8, u8, u8), msg: &str) {
-    canvas_text(x, y, 14.0, c.0, c.1, c.2, msg);
+    canvas_text(x, y, 14.0, c.0, c.1, c.2, 255, msg);
 }
 
 fn draw_note_row(x: f32, y: f32, note: &Note, tag: &str) {
@@ -141,7 +141,7 @@ pub extern "C" fn start_app() {
 
     // ── Title bar ────────────────────────────────────────────────────
     canvas_rect(0.0, 0.0, w, 50.0, TITLE_BG.0, TITLE_BG.1, TITLE_BG.2, 255);
-    canvas_text(20.0, 14.0, 22.0, 220, 200, 255, "Oxide Notes");
+    canvas_text(20.0, 14.0, 22.0, 220, 200, 255, 255, "Oxide Notes");
     canvas_text(
         20.0,
         38.0,
@@ -149,6 +149,7 @@ pub extern "C" fn start_app() {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "Full-stack demo  \u{2022}  WASM frontend  \u{2022}  Rust backend  \u{2022}  Protobuf wire format",
     );
 
@@ -373,7 +374,7 @@ pub extern "C" fn start_app() {
     canvas_circle(w - 110.0, 170.0, 18.0, 180, 140, 255, 70);
 
     // ── Separator at bottom ──────────────────────────────────────────
-    canvas_line(20.0, y, w - 20.0, y, DIM.0, DIM.1, DIM.2, 1.0);
+    canvas_line(20.0, y, w - 20.0, y, DIM.0, DIM.1, DIM.2, 255, 1.0);
     y += 12.0;
     draw_text(
         20.0,
@@ -390,8 +391,8 @@ pub extern "C" fn start_app() {
 fn render_offline(w: f32, err_code: i64) {
     canvas_clear(BG.0, BG.1, BG.2, 255);
     canvas_rect(0.0, 0.0, w, 50.0, TITLE_BG.0, TITLE_BG.1, TITLE_BG.2, 255);
-    canvas_text(20.0, 14.0, 22.0, 220, 200, 255, "Oxide Notes");
-    canvas_text(20.0, 38.0, 12.0, DIM.0, DIM.1, DIM.2, "Full-stack demo");
+    canvas_text(20.0, 14.0, 22.0, 220, 200, 255, 255, "Oxide Notes");
+    canvas_text(20.0, 38.0, 12.0, DIM.0, DIM.1, DIM.2, 255, "Full-stack demo");
 
     draw_text(
         20.0,

--- a/examples/hello-oxide/src/lib.rs
+++ b/examples/hello-oxide/src/lib.rs
@@ -15,10 +15,10 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     // ── Title bar ───────────────────────────────────────────────────
     canvas_rect(0.0, 0.0, width as f32, 56.0, 50, 40, 80, 255);
-    canvas_text(20.0, 16.0, 24.0, 220, 200, 255, "Oxide Interactive Widgets");
+    canvas_text(20.0, 16.0, 24.0, 220, 200, 255, 255, "Oxide Interactive Widgets");
 
     // ── Button demo ─────────────────────────────────────────────────
-    canvas_text(20.0, 75.0, 16.0, 180, 140, 255, "Button");
+    canvas_text(20.0, 75.0, 16.0, 180, 140, 255, 255, "Button");
 
     if ui_button(1, 20.0, 100.0, 120.0, 28.0, "Click Me!") {
         unsafe {
@@ -38,11 +38,12 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         160,
         220,
         160,
+        255,
         &format!("Count: {count}"),
     );
 
     // ── Checkbox demo ───────────────────────────────────────────────
-    canvas_text(20.0, 150.0, 16.0, 180, 140, 255, "Checkbox");
+    canvas_text(20.0, 150.0, 16.0, 180, 140, 255, 255, "Checkbox");
 
     let dark_mode = ui_checkbox(10, 20.0, 175.0, "Dark mode", false);
     let notifications = ui_checkbox(11, 20.0, 205.0, "Enable notifications", true);
@@ -54,11 +55,12 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         120,
         120,
         120,
+        255,
         &format!("dark={dark_mode}  notif={notifications}"),
     );
 
     // ── Slider demo ─────────────────────────────────────────────────
-    canvas_text(20.0, 250.0, 16.0, 180, 140, 255, "Slider");
+    canvas_text(20.0, 250.0, 16.0, 180, 140, 255, 255, "Slider");
 
     let volume = ui_slider(20, 20.0, 275.0, 300.0, 0.0, 100.0, 50.0);
     canvas_text(
@@ -68,6 +70,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         160,
         220,
         160,
+        255,
         &format!("Volume: {volume:.0}%"),
     );
 
@@ -79,17 +82,18 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         160,
         220,
         160,
+        255,
         &format!("Speed: {speed:.1}x"),
     );
 
     // ── Text input demo ─────────────────────────────────────────────
-    canvas_text(20.0, 355.0, 16.0, 180, 140, 255, "Text Input");
+    canvas_text(20.0, 355.0, 16.0, 180, 140, 255, 255, "Text Input");
 
     let name = ui_text_input(30, 20.0, 380.0, 300.0, "");
     if !name.is_empty() {
-        canvas_text(20.0, 415.0, 18.0, 160, 220, 160, &format!("Hello, {name}!"));
+        canvas_text(20.0, 415.0, 18.0, 160, 220, 160, 255, &format!("Hello, {name}!"));
     } else {
-        canvas_text(20.0, 415.0, 14.0, 120, 120, 120, "Type your name above...");
+        canvas_text(20.0, 415.0, 14.0, 120, 120, 120, 255, "Type your name above...");
     }
 
     // ── Mouse info ──────────────────────────────────────────────────
@@ -101,6 +105,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         100,
         100,
         120,
+        255,
         &format!(
             "Mouse: ({mx:.0}, {my:.0})  LMB: {}  RMB: {}",
             mouse_button_down(0),

--- a/examples/hello-oxide/src/lib.rs
+++ b/examples/hello-oxide/src/lib.rs
@@ -15,7 +15,16 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     // ── Title bar ───────────────────────────────────────────────────
     canvas_rect(0.0, 0.0, width as f32, 56.0, 50, 40, 80, 255);
-    canvas_text(20.0, 16.0, 24.0, 220, 200, 255, 255, "Oxide Interactive Widgets");
+    canvas_text(
+        20.0,
+        16.0,
+        24.0,
+        220,
+        200,
+        255,
+        255,
+        "Oxide Interactive Widgets",
+    );
 
     // ── Button demo ─────────────────────────────────────────────────
     canvas_text(20.0, 75.0, 16.0, 180, 140, 255, 255, "Button");
@@ -91,9 +100,27 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     let name = ui_text_input(30, 20.0, 380.0, 300.0, "");
     if !name.is_empty() {
-        canvas_text(20.0, 415.0, 18.0, 160, 220, 160, 255, &format!("Hello, {name}!"));
+        canvas_text(
+            20.0,
+            415.0,
+            18.0,
+            160,
+            220,
+            160,
+            255,
+            &format!("Hello, {name}!"),
+        );
     } else {
-        canvas_text(20.0, 415.0, 14.0, 120, 120, 120, 255, "Type your name above...");
+        canvas_text(
+            20.0,
+            415.0,
+            14.0,
+            120,
+            120,
+            120,
+            255,
+            "Type your name above...",
+        );
     }
 
     // ── Mouse info ──────────────────────────────────────────────────

--- a/examples/index/src/lib.rs
+++ b/examples/index/src/lib.rs
@@ -113,6 +113,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         ACCENT_GLOW.0,
         ACCENT_GLOW.1,
         ACCENT_GLOW.2,
+        255,
         "Oxide",
     );
     canvas_text(
@@ -122,6 +123,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "A WebAssembly-native application platform",
     );
     canvas_text(
@@ -131,6 +133,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "oxide.foundation",
     );
 
@@ -144,6 +147,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "v0.1.0",
     );
 
@@ -155,6 +159,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_BRIGHT.0,
         TEXT_BRIGHT.1,
         TEXT_BRIGHT.2,
+        255,
         "Demo Applications",
     );
     canvas_line(
@@ -165,6 +170,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIVIDER.0,
         DIVIDER.1,
         DIVIDER.2,
+        255,
         1.0,
     );
 
@@ -216,6 +222,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             card.color.0,
             card.color.1,
             card.color.2,
+            255,
             card.icon_char,
         );
 
@@ -227,6 +234,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             TEXT_BRIGHT.0,
             TEXT_BRIGHT.1,
             TEXT_BRIGHT.2,
+            255,
             card.title,
         );
 
@@ -238,6 +246,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             card.color.0,
             card.color.1,
             card.color.2,
+            255,
             card.subtitle,
         );
 
@@ -249,6 +258,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             TEXT_DIM.0,
             TEXT_DIM.1,
             TEXT_DIM.2,
+            255,
             card.description,
         );
 
@@ -261,6 +271,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
                 card.color.0,
                 card.color.1,
                 card.color.2,
+                255,
                 ">",
             );
         }
@@ -278,6 +289,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIVIDER.0,
         DIVIDER.1,
         DIVIDER.2,
+        255,
         1.0,
     );
 
@@ -288,6 +300,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "Built with Oxide SDK  |  Rust + WebAssembly  |  oxide.foundation",
     );
     canvas_text(
@@ -297,6 +310,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         TEXT_DIM.0,
         TEXT_DIM.1,
         TEXT_DIM.2,
+        255,
         "Click any card to launch the demo in this browser.",
     );
 }

--- a/examples/media-capture/src/lib.rs
+++ b/examples/media-capture/src/lib.rs
@@ -51,7 +51,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     canvas_clear(18, 20, 28, 255);
 
-    canvas_text(20.0, 16.0, 22.0, 220, 210, 255, "Media capture");
+    canvas_text(20.0, 16.0, 22.0, 220, 210, 255, 255, "Media capture");
     canvas_text(
         20.0,
         44.0,
@@ -59,6 +59,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         140,
         150,
         170,
+        255,
         "Camera / mic / screenshot use host dialogs + OS permissions.",
     );
 
@@ -144,6 +145,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
                 120,
                 128,
                 140,
+                255,
                 "Open camera to preview",
             );
         }
@@ -157,6 +159,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         160,
         165,
         180,
+        255,
         "Last screenshot",
     );
 
@@ -178,6 +181,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
                 100,
                 110,
                 125,
+                255,
                 "No grab yet",
             );
         }
@@ -193,6 +197,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         180,
         185,
         200,
+        255,
         "Microphone (mono)",
     );
     canvas_rect(meter_x, meter_y, meter_w, 14.0, 40, 44, 52, 255);
@@ -221,10 +226,11 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
                 130,
                 140,
                 155,
+                255,
                 &format!("{hz} Hz"),
             );
         } else {
-            canvas_text(meter_x + 8.0, meter_y - 2.0, 12.0, 100, 110, 125, "closed");
+            canvas_text(meter_x + 8.0, meter_y - 2.0, 12.0, 100, 110, 125, 255, "closed");
         }
     }
 
@@ -238,6 +244,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         90,
         95,
         105,
+        255,
         &format!("pipeline: cam_frames={frames} mic_ring~{ring}"),
     );
 }

--- a/examples/media-capture/src/lib.rs
+++ b/examples/media-capture/src/lib.rs
@@ -230,7 +230,16 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
                 &format!("{hz} Hz"),
             );
         } else {
-            canvas_text(meter_x + 8.0, meter_y - 2.0, 12.0, 100, 110, 125, 255, "closed");
+            canvas_text(
+                meter_x + 8.0,
+                meter_y - 2.0,
+                12.0,
+                100,
+                110,
+                125,
+                255,
+                "closed",
+            );
         }
     }
 

--- a/examples/timer-demo/src/lib.rs
+++ b/examples/timer-demo/src/lib.rs
@@ -69,13 +69,14 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
 
     // ── Header ──────────────────────────────────────────────────────
     canvas_rect(0.0, 0.0, w, 52.0, ACCENT.0, ACCENT.1, ACCENT.2, 255);
-    canvas_text(20.0, 14.0, 22.0, 255, 255, 255, "Oxide Timer Demo");
+    canvas_text(20.0, 14.0, 22.0, 255, 255, 255, 255, "Oxide Timer Demo");
     canvas_text(
         20.0,
         36.0,
         11.0,
         200,
         220,
+        255,
         255,
         "set_timeout / set_interval / clear_timer",
     );
@@ -88,6 +89,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "COUNTDOWN (set_interval)",
     );
 
@@ -126,15 +128,16 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         count_color.0,
         count_color.1,
         count_color.2,
+        255,
         &count_text,
     );
 
     if countdown == 0 && !running {
-        canvas_text(260.0, 105.0, 14.0, DIM.0, DIM.1, DIM.2, "Done!");
+        canvas_text(260.0, 105.0, 14.0, DIM.0, DIM.1, DIM.2, 255, "Done!");
     }
 
     // ── Delayed Message (set_timeout) ───────────────────────────────
-    canvas_line(20.0, 145.0, w - 20.0, 145.0, 40, 35, 60, 1.0);
+    canvas_line(20.0, 145.0, w - 20.0, 145.0, 40, 35, 60, 255, 1.0);
     canvas_text(
         20.0,
         160.0,
@@ -142,6 +145,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "DELAYED MESSAGE (set_timeout)",
     );
 
@@ -157,11 +161,11 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         } else {
             GREEN
         };
-        canvas_text(220.0, 190.0, 14.0, color.0, color.1, color.2, msg);
+        canvas_text(220.0, 190.0, 14.0, color.0, color.1, color.2, 255, msg);
     }
 
     // ── Blink (set_interval + clear_timer) ──────────────────────────
-    canvas_line(20.0, 230.0, w - 20.0, 230.0, 40, 35, 60, 1.0);
+    canvas_line(20.0, 230.0, w - 20.0, 230.0, 40, 35, 60, 255, 1.0);
     canvas_text(
         20.0,
         245.0,
@@ -169,6 +173,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "BLINK (interval + clear)",
     );
 
@@ -205,6 +210,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         if blinking {
             "Toggling every 500ms"
         } else {
@@ -213,7 +219,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
     );
 
     // ── Stopwatch (set_interval + clear_timer) ──────────────────────
-    canvas_line(20.0, 315.0, w - 20.0, 315.0, 40, 35, 60, 1.0);
+    canvas_line(20.0, 315.0, w - 20.0, 315.0, 40, 35, 60, 255, 1.0);
     canvas_text(
         20.0,
         330.0,
@@ -221,6 +227,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "STOPWATCH (100ms interval)",
     );
 
@@ -251,11 +258,12 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         BRIGHT.0,
         BRIGHT.1,
         BRIGHT.2,
+        255,
         &format!("{secs}.{tenths}s"),
     );
 
     // ── Info ─────────────────────────────────────────────────────────
-    canvas_line(20.0, 405.0, w - 20.0, 405.0, 40, 35, 60, 1.0);
+    canvas_line(20.0, 405.0, w - 20.0, 405.0, 40, 35, 60, 255, 1.0);
     canvas_text(
         20.0,
         420.0,
@@ -263,6 +271,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "Timers fire via exported on_timer(callback_id). Intervals repeat until cleared.",
     );
     canvas_text(
@@ -272,6 +281,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         DIM.0,
         DIM.1,
         DIM.2,
+        255,
         "Resolution is tied to the frame rate (~16ms at 60fps).",
     );
 }

--- a/examples/video-player/src/lib.rs
+++ b/examples/video-player/src/lib.rs
@@ -34,6 +34,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             220,
             120,
             120,
+            255,
             "video_render failed — load a video or check network / FFmpeg",
         );
         return;
@@ -47,6 +48,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
         180,
         180,
         200,
+        255,
         &format!("{pos} / {dur} ms"),
     );
     if ui_button(1, 40.0, ch as f32 - 52.0, 120.0, 36.0, "Pause") {

--- a/oxide-browser/Cargo.toml
+++ b/oxide-browser/Cargo.toml
@@ -16,8 +16,6 @@ path = "src/main.rs"
 wasmtime = "29"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "blocking"], default-features = false }
-eframe = "0.31"
-egui = "0.31"
 rfd = "0.15"
 arboard = "3"
 anyhow = "1"
@@ -38,6 +36,8 @@ tempfile = "3"
 nokhwa = { version = "0.10.10", features = ["input-native", "camera-sync-impl"] }
 cpal = "0.17.3"
 screenshots = "0.8.10"
+gpui = "0.2.2"
+smallvec = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/oxide-browser/src/audio_format.rs
+++ b/oxide-browser/src/audio_format.rs
@@ -59,7 +59,7 @@ pub fn sniff_audio_format(data: &[u8]) -> u32 {
     AUDIO_FORMAT_UNKNOWN
 }
 
-/// Map a `Content-Type` (or similar) value to [`AUDIO_FORMAT_*`], or [`AUDIO_FORMAT_UNKNOWN`].
+/// Map a `Content-Type` (or similar) value to an `AUDIO_FORMAT_*` constant, or [`AUDIO_FORMAT_UNKNOWN`].
 pub fn mime_to_audio_format(mime: &str) -> u32 {
     let s = mime
         .split(';')

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -235,7 +235,7 @@ pub enum DrawCommand {
         b: u8,
         a: u8,
     },
-    /// Text baseline position `(x, y)`, font size in pixels, RGB color, and string payload.
+    /// Text baseline position `(x, y)`, font size in pixels, RGBA color, and string payload.
     Text {
         x: f32,
         y: f32,
@@ -243,9 +243,10 @@ pub enum DrawCommand {
         r: u8,
         g: u8,
         b: u8,
+        a: u8,
         text: String,
     },
-    /// Line from `(x1, y1)` to `(x2, y2)` with RGB stroke color and stroke width in pixels.
+    /// Line from `(x1, y1)` to `(x2, y2)` with RGBA stroke color and stroke width in pixels.
     Line {
         x1: f32,
         y1: f32,
@@ -254,6 +255,7 @@ pub enum DrawCommand {
         r: u8,
         g: u8,
         b: u8,
+        a: u8,
         thickness: f32,
     },
     /// Draw [`DecodedImage`] `image_id` from `images` into the axis-aligned rectangle `(x, y, w, h)`.
@@ -492,6 +494,7 @@ fn video_render_at(
             r: 255,
             g: 255,
             b: 255,
+            a: 255,
             text,
         });
     }
@@ -770,6 +773,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
          r: u32,
          g: u32,
          b: u32,
+         a: u32,
          txt_ptr: u32,
          txt_len: u32| {
             let mem = caller.data().memory.expect("memory not set");
@@ -787,6 +791,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                     r: r as u8,
                     g: g as u8,
                     b: b as u8,
+                    a: a as u8,
                     text,
                 });
         },
@@ -803,6 +808,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
          r: u32,
          g: u32,
          b: u32,
+         a: u32,
          thickness: f32| {
             caller
                 .data()
@@ -818,6 +824,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                     r: r as u8,
                     g: g as u8,
                     b: b as u8,
+                    a: a as u8,
                     thickness,
                 });
         },

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -143,7 +143,7 @@ pub struct HostState {
     pub widget_states: Arc<Mutex<HashMap<u32, WidgetValue>>>,
     /// Button IDs that were clicked during the last render pass.
     pub widget_clicked: Arc<Mutex<HashSet<u32>>>,
-    /// Top-left corner of the canvas panel in egui screen coords.
+    /// Top-left corner of the canvas panel in GPUI screen coords.
     pub canvas_offset: Arc<Mutex<(f32, f32)>>,
     /// Persistent bookmark storage shared across tabs.
     pub bookmark_store: SharedBookmarkStore,
@@ -324,7 +324,7 @@ pub struct Hyperlink {
     pub url: String,
 }
 
-/// Per-frame input snapshot from the host (egui) for guest polling via `api_mouse_*`, `api_key_*`, etc.
+/// Per-frame input snapshot from the host (GPUI) for guest polling via `api_mouse_*`, `api_key_*`, etc.
 #[derive(Clone, Debug, Default)]
 pub struct InputState {
     /// Pointer horizontal position in window/content coordinates before canvas offset subtraction in APIs.
@@ -351,7 +351,7 @@ pub struct InputState {
     pub scroll_y: f32,
 }
 
-/// UI control the guest requested for the current frame; the host egui layer renders these after canvas content.
+/// UI control the guest requested for the current frame; the host GPUI layer renders these after canvas content.
 ///
 /// Commands are queued during `on_frame`; stable `id` values tie widgets to [`WidgetValue`] state and click tracking.
 #[derive(Clone, Debug)]

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -48,7 +48,36 @@
 //! | [`navigation`] | Browser history stack with back/forward traversal |
 //! | [`bookmarks`] | Persistent bookmark storage backed by sled |
 //! | [`url`] | WHATWG-compliant URL parsing with Oxide-specific schemes |
-//! | [`ui`] | egui/eframe desktop UI (toolbar, canvas, console, tabs) |
+//! | [`ui`] | GPUI desktop shell (toolbar, canvas, console, tabs) |
+//!
+//! ## Which API do I need?
+//!
+//! | You are building… | Use this crate | Notes |
+//! |---|---|---|
+//! | A **guest** `.wasm` app (canvas, fetch, widgets) | **`oxide-sdk` only** | Import `oxide::*` via the SDK; you never link `oxide-browser`. |
+//! | The **stock desktop browser** binary | **`cargo run -p oxide-browser`** | The `oxide` binary wires [`runtime::BrowserHost`] to [`ui::run_browser`]. |
+//! | A **custom native shell** (alternate windowing, tests, automation) | [`ui::run_browser`] + [`runtime::BrowserHost`] | Same [`capabilities::HostState`] pipeline; swap or wrap the GPUI window if needed. |
+//! | **GPU/UI work** next to Oxide (panels, overlays, devtools) | [`gpui`] | Re-export of [GPUI](https://www.gpui.rs/); version matches this crate’s dependency. |
+//!
+//! ### Relationship between GPUI and the SDK
+//!
+//! Guest `.wasm` modules cannot link GPUI directly (it requires native GPU
+//! access). Instead, the `oxide-sdk` crate provides drawing functions that
+//! the host translates into GPUI primitives each frame:
+//!
+//! - `canvas_rect` → `Window::paint_quad` with `gpui::fill`
+//! - `canvas_circle` → `Window::paint_path` with polygon approximation
+//! - `canvas_text` → GPU text shaping via `Window::text_system().shape_line`
+//! - `canvas_line` → `Window::paint_path` with `PathBuilder::stroke`
+//! - `canvas_image` → `Window::paint_image` with `RenderImage` texture cache
+//!
+//! The `oxide_sdk::draw` module provides higher-level types (`Canvas`,
+//! `Color`, `Rect`, `Point2D`) modelled after GPUI conventions.
+//!
+//! ### Host entrypoints (Rust)
+//!
+//! - **[`ui::run_browser`]** — Blocks on the GPUI event loop and opens the main Oxide window. Pass the shared [`capabilities::HostState`] and [`runtime::PageStatus`] from a [`runtime::BrowserHost`].
+//! - **`gpui`** — Full GPUI API for native code that ships beside the browser (not available inside guest wasm).
 //!
 //! ## Security Model
 //!
@@ -74,3 +103,10 @@ pub mod ui;
 pub mod url;
 pub mod video;
 pub mod video_format;
+
+/// GPU-accelerated UI framework used by the desktop shell (see [GPUI](https://www.gpui.rs/)).
+///
+/// Depend on `oxide-browser` and `use oxide_browser::gpui` so your native tooling stays on the same
+/// GPUI version as the browser. Guest WebAssembly modules cannot use this crate; they use the
+/// [`oxide-sdk`](https://docs.rs/oxide-sdk) crate instead.
+pub use gpui;

--- a/oxide-browser/src/main.rs
+++ b/oxide-browser/src/main.rs
@@ -7,24 +7,6 @@ fn main() -> Result<()> {
     let host_state = host.host_state.clone();
     let status = host.status.clone();
 
-    let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default()
-            .with_title("Oxide Browser")
-            .with_inner_size([1024.0, 720.0])
-            .with_min_inner_size([600.0, 400.0]),
-        ..Default::default()
-    };
-
-    eframe::run_native(
-        "Oxide Browser",
-        native_options,
-        Box::new(move |_cc| {
-            Ok(Box::new(oxide_browser::ui::OxideApp::new(
-                host_state, status,
-            )))
-        }),
-    )
-    .map_err(|e| anyhow::anyhow!("eframe error: {e}"))?;
-
+    oxide_browser::ui::run_browser(host_state, status)?;
     Ok(())
 }

--- a/oxide-browser/src/ui.rs
+++ b/oxide-browser/src/ui.rs
@@ -43,6 +43,9 @@ struct RunResult {
     live_module: Option<LiveModule>,
 }
 
+// SAFETY: `LiveModule` contains a wasmtime `Store<HostState>` whose fields are
+// behind `Arc<Mutex<…>>`, making them safe to send across threads. The `error`
+// field is a plain `Option<String>`.
 unsafe impl Send for RunResult {}
 
 struct TabState {
@@ -251,13 +254,11 @@ impl TabState {
         input.scroll_y = 0.0;
     }
 
-    fn update_texture_cache(&mut self, window: &mut Window) {
+    fn update_texture_cache(&mut self, _window: &mut Window) {
         let tab_id = self.id;
         let canvas = self.host_state.canvas.lock().unwrap();
         if canvas.generation != self.canvas_generation {
-            for (_, img) in self.image_textures.drain() {
-                let _ = window.drop_image(img);
-            }
+            self.image_textures.clear();
             self.canvas_generation = canvas.generation;
         }
         for (i, decoded) in canvas.images.iter().enumerate() {
@@ -267,12 +268,10 @@ impl TabState {
         }
     }
 
-    fn refresh_pip_texture(&mut self, window: &mut Window) {
+    fn refresh_pip_texture(&mut self, _window: &mut Window) {
         let pip = self.host_state.video.lock().unwrap().pip;
         if !pip {
-            if let Some(old) = self.pip_texture.take() {
-                let _ = window.drop_image(old);
-            }
+            self.pip_texture = None;
             self.pip_last_serial = 0;
             return;
         }
@@ -280,9 +279,7 @@ impl TabState {
         let serial = *self.host_state.video_pip_serial.lock().unwrap();
         if serial != self.pip_last_serial {
             self.pip_last_serial = serial;
-            if let Some(old) = self.pip_texture.take() {
-                let _ = window.drop_image(old);
-            }
+            self.pip_texture = None;
             let frame = self.host_state.video_pip_frame.lock().unwrap().clone();
             if let Some(decoded) = frame {
                 self.pip_texture = Some(decoded_to_render_image(
@@ -315,13 +312,6 @@ fn rgba8(r: u8, g: u8, b: u8, a: u8) -> gpui::Hsla {
         b: b as f32 / 255.0,
         a: a as f32 / 255.0,
     })
-}
-
-/// Solid text color from sRGB bytes (GPUI `TextRun` uses [`Hsla`]).
-fn text_rgb_u8(r: u8, g: u8, b: u8) -> gpui::Hsla {
-    gpui::Hsla::from(gpui::rgb(
-        ((r as u32) << 16) | ((g as u32) << 8) | (b as u32),
-    ))
 }
 
 fn circle_polygon(cx: f32, cy: f32, radius: f32) -> Vec<Point<Pixels>> {
@@ -390,6 +380,7 @@ fn paint_draw_commands(
                 r,
                 g,
                 b,
+                a,
                 text,
             } => {
                 let origin = rect.origin + point(px(*x), px(*y));
@@ -397,7 +388,7 @@ fn paint_draw_commands(
                 let run = TextRun {
                     len: text_owned.len(),
                     font: font(".SystemUIFont"),
-                    color: text_rgb_u8(*r, *g, *b),
+                    color: rgba8(*r, *g, *b, *a),
                     background_color: None,
                     underline: None,
                     strikethrough: None,
@@ -418,6 +409,7 @@ fn paint_draw_commands(
                 r,
                 g,
                 b,
+                a,
                 thickness,
             } => {
                 let p1 = rect.origin + point(px(*x1), px(*y1));
@@ -426,7 +418,7 @@ fn paint_draw_commands(
                 pb.move_to(p1);
                 pb.line_to(p2);
                 if let Ok(path) = pb.build() {
-                    window.paint_path(path, rgba8(*r, *g, *b, 255));
+                    window.paint_path(path, rgba8(*r, *g, *b, *a));
                 }
             }
             DrawCommand::Image {
@@ -636,7 +628,7 @@ impl Render for OxideBrowserView {
             .lock()
             .unwrap()
             .can_go_back();
-        let _can_fwd = self.tabs[active]
+        let can_fwd = self.tabs[active]
             .host_state
             .navigation
             .lock()
@@ -832,16 +824,20 @@ impl Render for OxideBrowserView {
         );
 
         // Toolbar
-        let status_icon = match &*self.tabs[active].status.lock().unwrap() {
-            PageStatus::Idle => "○",
-            PageStatus::Loading(_) => "↻",
-            PageStatus::Running(_) => "●",
-            PageStatus::Error(_) => "●",
-        };
-        let status_color = match &*self.tabs[active].status.lock().unwrap() {
-            PageStatus::Error(_) => gpui::rgb(0xf05050),
-            PageStatus::Running(_) => gpui::rgb(0x50e070),
-            _ => gpui::rgb(0xa0a0a8),
+        let (status_icon, status_color) = {
+            let status = self.tabs[active].status.lock().unwrap();
+            let icon = match &*status {
+                PageStatus::Idle => "○",
+                PageStatus::Loading(_) => "↻",
+                PageStatus::Running(_) => "●",
+                PageStatus::Error(_) => "●",
+            };
+            let color = match &*status {
+                PageStatus::Error(_) => gpui::rgb(0xf05050),
+                PageStatus::Running(_) => gpui::rgb(0x50e070),
+                _ => gpui::rgb(0xa0a0a8),
+            };
+            (icon, color)
         };
 
         root = root.child(
@@ -857,11 +853,14 @@ impl Render for OxideBrowserView {
                 .child(
                     div()
                         .id("oxide_back")
-                        .cursor_pointer()
+                        .when(can_back, |el| el.cursor_pointer())
                         .text_sm()
-                        .text_color(gpui::rgb(0xb8b8c4))
+                        .text_color(if can_back {
+                            gpui::rgb(0xb8b8c4)
+                        } else {
+                            gpui::rgb(0x50505a)
+                        })
                         .child("◀")
-                        .when(can_back, |d| d)
                         .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
                             this.tabs[this.active_tab].go_back();
                             cx.notify();
@@ -870,9 +869,13 @@ impl Render for OxideBrowserView {
                 .child(
                     div()
                         .id("oxide_forward")
-                        .cursor_pointer()
+                        .when(can_fwd, |el| el.cursor_pointer())
                         .text_sm()
-                        .text_color(gpui::rgb(0xb8b8c4))
+                        .text_color(if can_fwd {
+                            gpui::rgb(0xb8b8c4)
+                        } else {
+                            gpui::rgb(0x50505a)
+                        })
                         .child("▶")
                         .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
                             this.tabs[this.active_tab].go_forward();

--- a/oxide-browser/src/ui.rs
+++ b/oxide-browser/src/ui.rs
@@ -1,18 +1,31 @@
-//! Desktop GUI for Oxide using [egui](https://github.com/emilk/egui) and [eframe](https://github.com/emilk/egui/tree/master/crates/eframe).
+//! Desktop shell for Oxide using [GPUI](https://www.gpui.rs/) (Zed’s GPU-accelerated UI framework).
 //!
-//! This module implements a multi-tab browser shell: toolbar, canvas renderer, console panel,
-//! bookmarks sidebar, and an about dialog. The canvas draws guest WebAssembly output—rectangles,
-//! circles, text, lines, and images—via the host’s draw command stream. Interactive widgets
-//! (buttons, checkboxes, sliders, text inputs) are issued by the guest and rendered each frame.
-//! Hyperlinks drawn on the canvas are hit-tested so clicks trigger navigation.
+//! Guest canvas commands are painted with [`Window::paint_quad`], [`Window::paint_path`],
+//! [`Window::paint_image`], and GPU text shaping — bitmaps (including video frames) are uploaded as
+//! [`RenderImage`] textures and composited on the GPU.
 //!
-//! **Shortcuts:** Cmd+T new tab, Cmd+W close tab, Ctrl+Tab next tab, Cmd+D toggle bookmark for the
-//! current page, Cmd+B toggle the bookmarks panel.
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
+//! ## Public API
+//!
+//! - [`run_browser`] — Start the GPUI [`Application`] and open the main browser window; pass
+//!   [`HostState`] and page status from [`crate::runtime::BrowserHost`].
+//! - [`OxideBrowserView`] — Root view: tabs, toolbar, canvas [`canvas`] element, console, and bookmarks.
 
-use eframe::egui;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::mpsc::{self, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use gpui::prelude::*;
+use gpui::{
+    canvas, div, font, img, point, px, size, Application, Bounds, ClickEvent, FocusHandle,
+    ImageSource, InteractiveElement, KeyDownEvent, KeyUpEvent, Keystroke, MouseButton,
+    MouseDownEvent, MouseUpEvent, PathBuilder, Pixels, Point, Render, RenderImage, Rgba,
+    ScrollDelta, ScrollWheelEvent, SharedString, TextRun, TitlebarOptions, Window, WindowBounds,
+    WindowKind, WindowOptions,
+};
+use image::Frame;
+use smallvec::smallvec;
 
 use crate::bookmarks::BookmarkStore;
 use crate::capabilities::{ConsoleLevel, DrawCommand, HostState, WidgetCommand, WidgetValue};
@@ -30,11 +43,7 @@ struct RunResult {
     live_module: Option<LiveModule>,
 }
 
-// Send is required to pass LiveModule through the channel.
-// Store<HostState> is Send because HostState fields are Arc<Mutex<>>.
 unsafe impl Send for RunResult {}
-
-// ── Per-tab state ───────────────────────────────────────────────────────────
 
 struct TabState {
     id: u64,
@@ -44,15 +53,18 @@ struct TabState {
     show_console: bool,
     run_tx: std::sync::mpsc::Sender<RunRequest>,
     run_rx: Arc<Mutex<std::sync::mpsc::Receiver<RunResult>>>,
-    image_textures: HashMap<usize, egui::TextureHandle>,
-    /// Picture-in-picture floating preview (video frame copy).
-    pip_texture: Option<egui::TextureHandle>,
+    /// GPU texture cache for decoded canvas images (video frames use the same path).
+    image_textures: HashMap<usize, Arc<RenderImage>>,
+    pip_texture: Option<Arc<RenderImage>>,
     pip_last_serial: u64,
     canvas_generation: u64,
     pending_history_url: Option<String>,
     hovered_link_url: Option<String>,
     live_module: Option<LiveModule>,
     last_frame: Instant,
+    keys_held: HashSet<u32>,
+    /// Guest `TextInput` widget id with keyboard focus, if any.
+    text_input_focus: Option<u32>,
 }
 
 impl TabState {
@@ -95,6 +107,8 @@ impl TabState {
             hovered_link_url: None,
             live_module: None,
             last_frame: Instant::now(),
+            keys_held: HashSet::new(),
+            text_input_focus: None,
         }
     }
 
@@ -107,8 +121,6 @@ impl TabState {
             PageStatus::Error(_) => "Error".to_string(),
         }
     }
-
-    // ── Navigation ──────────────────────────────────────────────────────
 
     fn navigate(&mut self) {
         let url = self.url_input.trim().to_string();
@@ -151,100 +163,6 @@ impl TabState {
         }
     }
 
-    fn load_local_file(&mut self) {
-        if let Some(path) = rfd::FileDialog::new()
-            .add_filter("WebAssembly", &["wasm"])
-            .set_title("Open .wasm Application")
-            .pick_file()
-        {
-            if let Ok(bytes) = std::fs::read(&path) {
-                let file_url = format!("file://{}", path.display());
-                self.url_input = file_url.clone();
-                self.pending_history_url = Some(file_url);
-                let _ = self.run_tx.send(RunRequest::LoadLocal(bytes));
-            }
-        }
-    }
-
-    // ── Frame lifecycle ─────────────────────────────────────────────────
-
-    fn capture_input(&self, ctx: &egui::Context) {
-        let mut input = self.host_state.input_state.lock().unwrap();
-
-        ctx.input(|i| {
-            if let Some(pos) = i.pointer.hover_pos() {
-                input.mouse_x = pos.x;
-                input.mouse_y = pos.y;
-            }
-
-            input.mouse_buttons_down[0] = i.pointer.primary_down();
-            input.mouse_buttons_down[1] = i.pointer.secondary_down();
-            input.mouse_buttons_down[2] = i.pointer.middle_down();
-
-            input.mouse_buttons_clicked[0] = i.pointer.primary_clicked();
-            input.mouse_buttons_clicked[1] = i.pointer.secondary_clicked();
-            input.mouse_buttons_clicked[2] = i.pointer.middle_down() && i.pointer.any_pressed();
-
-            input.modifiers_shift = i.modifiers.shift;
-            input.modifiers_ctrl = i.modifiers.ctrl;
-            input.modifiers_alt = i.modifiers.alt;
-
-            input.scroll_x = i.smooth_scroll_delta.x;
-            input.scroll_y = i.smooth_scroll_delta.y;
-
-            input.keys_down.clear();
-            input.keys_pressed.clear();
-            for event in &i.events {
-                if let egui::Event::Key { key, pressed, .. } = event {
-                    if let Some(code) = egui_key_to_oxide(key) {
-                        if *pressed {
-                            input.keys_pressed.push(code);
-                        }
-                        if *pressed {
-                            input.keys_down.push(code);
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-    fn tick_frame(&mut self) {
-        if self.live_module.is_none() {
-            return;
-        }
-
-        let now = Instant::now();
-        let dt = now - self.last_frame;
-        self.last_frame = now;
-        let dt_ms = dt.as_millis().min(100) as u32;
-
-        self.host_state.widget_commands.lock().unwrap().clear();
-
-        if let Some(ref mut live) = self.live_module {
-            match live.tick(dt_ms) {
-                Ok(()) => {}
-                Err(e) => {
-                    let msg = if e.to_string().contains("fuel") {
-                        "on_frame halted: fuel limit exceeded".to_string()
-                    } else {
-                        format!("on_frame error: {e}")
-                    };
-                    crate::capabilities::console_log(
-                        &self.host_state.console,
-                        ConsoleLevel::Error,
-                        msg.clone(),
-                    );
-                    *self.status.lock().unwrap() = PageStatus::Error(msg);
-                    self.live_module = None;
-                    return;
-                }
-            }
-        }
-
-        self.host_state.widget_clicked.lock().unwrap().clear();
-    }
-
     fn drain_results(&mut self) {
         if let Ok(rx) = self.run_rx.lock() {
             while let Ok(result) = rx.try_recv() {
@@ -284,533 +202,77 @@ impl TabState {
         }
     }
 
-    // ── Rendering ───────────────────────────────────────────────────────
+    fn sync_keys_held_to_input(&self) {
+        let mut input = self.host_state.input_state.lock().unwrap();
+        input.keys_down.clear();
+        input.keys_down.extend(self.keys_held.iter().copied());
+    }
 
-    fn render_toolbar(
-        &mut self,
-        ctx: &egui::Context,
-        bookmark_store: &Option<BookmarkStore>,
-        show_bookmarks: &mut bool,
-        show_about: &mut bool,
-    ) {
-        let can_back = self.host_state.navigation.lock().unwrap().can_go_back();
-        let can_fwd = self.host_state.navigation.lock().unwrap().can_go_forward();
-
-        let status_icon = match &*self.status.lock().unwrap() {
-            PageStatus::Idle => "\u{26AA}",
-            PageStatus::Loading(_) => "\u{1F504}",
-            PageStatus::Running(_) => "\u{1F7E2}",
-            PageStatus::Error(_) => "\u{1F534}",
+    fn tick_frame(&mut self) {
+        if self.live_module.is_none() {
+            return;
         }
-        .to_string();
 
-        let status = self.status.lock().unwrap().clone();
+        let now = Instant::now();
+        let dt = now - self.last_frame;
+        self.last_frame = now;
+        let dt_ms = dt.as_millis().min(100) as u32;
 
-        let current_url = self.url_input.clone();
-        let is_bookmarked = bookmark_store
-            .as_ref()
-            .map(|s| s.contains(&current_url))
-            .unwrap_or(false);
+        self.host_state.widget_commands.lock().unwrap().clear();
 
-        let mut toggle_bookmark = false;
-        let mut toggle_panel = false;
-
-        egui::TopBottomPanel::top("toolbar").show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-
-                let back_btn = ui.add_enabled(
-                    can_back,
-                    egui::Button::new(egui::RichText::new("\u{25C0}").size(14.0))
-                        .corner_radius(12.0)
-                        .min_size(egui::vec2(28.0, 28.0))
-                        .frame(false),
-                );
-                if back_btn.clicked() {
-                    self.go_back();
-                }
-                if back_btn.hovered() && can_back {
-                    back_btn.on_hover_text("Back");
-                }
-
-                let fwd_btn = ui.add_enabled(
-                    can_fwd,
-                    egui::Button::new(egui::RichText::new("\u{25B6}").size(14.0))
-                        .corner_radius(12.0)
-                        .min_size(egui::vec2(28.0, 28.0))
-                        .frame(false),
-                );
-                if fwd_btn.clicked() {
-                    self.go_forward();
-                }
-                if fwd_btn.hovered() && can_fwd {
-                    fwd_btn.on_hover_text("Forward");
-                }
-
-                ui.label(egui::RichText::new(&status_icon).size(16.0));
-
-                let response = ui.add(
-                    egui::TextEdit::singleline(&mut self.url_input)
-                        .desired_width(ui.available_width() - 190.0)
-                        .hint_text("Enter .wasm URL...")
-                        .font(egui::TextStyle::Monospace),
-                );
-                if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                    self.navigate();
-                }
-
-                let has_url =
-                    !self.url_input.trim().is_empty() && self.url_input.trim() != "https://";
-
-                if has_url {
-                    let star = if is_bookmarked {
-                        "\u{2605}" // filled star
+        if let Some(ref mut live) = self.live_module {
+            match live.tick(dt_ms) {
+                Ok(()) => {}
+                Err(e) => {
+                    let msg = if e.to_string().contains("fuel") {
+                        "on_frame halted: fuel limit exceeded".to_string()
                     } else {
-                        "\u{2606}" // outline star
+                        format!("on_frame error: {e}")
                     };
-                    let star_color = if is_bookmarked {
-                        egui::Color32::from_rgb(255, 200, 50)
-                    } else {
-                        egui::Color32::from_rgb(160, 160, 170)
-                    };
-                    let star_btn = ui.add(
-                        egui::Button::new(egui::RichText::new(star).size(18.0).color(star_color))
-                            .frame(false)
-                            .min_size(egui::vec2(28.0, 28.0)),
+                    crate::capabilities::console_log(
+                        &self.host_state.console,
+                        crate::capabilities::ConsoleLevel::Error,
+                        msg.clone(),
                     );
-                    if star_btn.clicked() {
-                        toggle_bookmark = true;
-                    }
-                    star_btn.on_hover_text(if is_bookmarked {
-                        "Remove bookmark"
-                    } else {
-                        "Add bookmark"
-                    });
+                    *self.status.lock().unwrap() = PageStatus::Error(msg);
+                    self.live_module = None;
                 }
+            }
+        }
 
-                if ui.button("Go").clicked() {
-                    self.navigate();
-                }
-                if ui.button("Open File").clicked() {
-                    self.load_local_file();
-                }
+        self.host_state.widget_clicked.lock().unwrap().clear();
+    }
 
-                let book_size = egui::vec2(28.0, 28.0);
-                let (book_rect, book_resp) =
-                    ui.allocate_exact_size(book_size, egui::Sense::click());
-                if ui.is_rect_visible(book_rect) {
-                    let c = book_rect.center();
-                    let book_color = if *show_bookmarks {
-                        egui::Color32::from_rgb(255, 200, 50)
-                    } else if book_resp.hovered() {
-                        egui::Color32::from_rgb(220, 220, 230)
-                    } else {
-                        egui::Color32::from_rgb(160, 160, 170)
-                    };
-                    let stroke = egui::Stroke::new(1.5, book_color);
-                    let hw = 6.0;
-                    let hh = 7.0;
-                    let spine_x = c.x - hw;
-                    ui.painter().rect_stroke(
-                        egui::Rect::from_min_size(
-                            egui::pos2(spine_x, c.y - hh),
-                            egui::vec2(hw * 2.0, hh * 2.0),
-                        ),
-                        egui::CornerRadius::same(2),
-                        stroke,
-                        egui::StrokeKind::Outside,
-                    );
-                    ui.painter().line_segment(
-                        [egui::pos2(c.x, c.y - hh), egui::pos2(c.x, c.y + hh)],
-                        stroke,
-                    );
-                }
-                if book_resp.clicked() {
-                    toggle_panel = true;
-                }
-                book_resp.on_hover_text(if *show_bookmarks {
-                    "Hide bookmarks"
-                } else {
-                    "Show bookmarks"
-                });
+    fn post_tick_clear_input(&mut self) {
+        let mut input = self.host_state.input_state.lock().unwrap();
+        input.keys_pressed.clear();
+        input.mouse_buttons_clicked = [false; 3];
+        input.scroll_x = 0.0;
+        input.scroll_y = 0.0;
+    }
 
-                // ── Three-dots overflow menu ─────────────────────
-                let dot_size = egui::vec2(28.0, 28.0);
-                let (menu_rect, menu_resp) = ui.allocate_exact_size(dot_size, egui::Sense::click());
-                if ui.is_rect_visible(menu_rect) {
-                    let c = menu_rect.center();
-                    let dot_color = if menu_resp.hovered() {
-                        egui::Color32::from_rgb(220, 220, 230)
-                    } else {
-                        egui::Color32::from_rgb(160, 160, 170)
-                    };
-                    let r = 2.0;
-                    let gap = 5.0;
-                    ui.painter()
-                        .circle_filled(c + egui::vec2(0.0, -gap), r, dot_color);
-                    ui.painter().circle_filled(c, r, dot_color);
-                    ui.painter()
-                        .circle_filled(c + egui::vec2(0.0, gap), r, dot_color);
-                }
-                let menu_id = ui.make_persistent_id("toolbar_overflow_menu");
-                if menu_resp.clicked() {
-                    ui.memory_mut(|mem| mem.toggle_popup(menu_id));
-                }
-                let menu_resp = menu_resp.on_hover_text("Menu");
-                egui::popup_below_widget(
-                    ui,
-                    menu_id,
-                    &menu_resp,
-                    egui::PopupCloseBehavior::CloseOnClick,
-                    |ui| {
-                        ui.set_min_width(160.0);
-
-                        let console_label = if self.show_console {
-                            "Hide Console"
-                        } else {
-                            "Show Console"
-                        };
-                        if ui.button(console_label).clicked() {
-                            self.show_console = !self.show_console;
-                        }
-
-                        ui.separator();
-
-                        if ui.button("About Oxide").clicked() {
-                            *show_about = true;
-                        }
-                    },
-                );
+    fn update_texture_cache(&mut self, window: &mut Window) {
+        let tab_id = self.id;
+        let canvas = self.host_state.canvas.lock().unwrap();
+        if canvas.generation != self.canvas_generation {
+            for (_, img) in self.image_textures.drain() {
+                let _ = window.drop_image(img);
+            }
+            self.canvas_generation = canvas.generation;
+        }
+        for (i, decoded) in canvas.images.iter().enumerate() {
+            self.image_textures.entry(i).or_insert_with(|| {
+                decoded_to_render_image(decoded, format!("oxide_img_{i}_tab{tab_id}"))
             });
-
-            if let PageStatus::Error(ref msg) = status {
-                ui.colored_label(egui::Color32::from_rgb(220, 50, 50), msg);
-            }
-        });
-
-        if toggle_bookmark {
-            if let Some(store) = bookmark_store.as_ref() {
-                if is_bookmarked {
-                    let _ = store.remove(&current_url);
-                } else {
-                    let title = url_to_title(&current_url);
-                    let _ = store.add(&current_url, &title);
-                }
-            }
-        }
-
-        if toggle_panel {
-            *show_bookmarks = !*show_bookmarks;
         }
     }
 
-    fn render_canvas(&mut self, ctx: &egui::Context) {
-        // Phase 1: Update texture cache from decoded images.
-        {
-            let canvas = self.host_state.canvas.lock().unwrap();
-            if canvas.generation != self.canvas_generation {
-                self.image_textures.clear();
-                self.canvas_generation = canvas.generation;
-            }
-            let tab_id = self.id;
-            for (i, decoded) in canvas.images.iter().enumerate() {
-                self.image_textures.entry(i).or_insert_with(|| {
-                    let color_image = egui::ColorImage::from_rgba_unmultiplied(
-                        [decoded.width as usize, decoded.height as usize],
-                        &decoded.pixels,
-                    );
-                    ctx.load_texture(
-                        format!("oxide_img_{i}_tab{tab_id}"),
-                        color_image,
-                        egui::TextureOptions::LINEAR,
-                    )
-                });
-            }
-        }
-
-        // Phase 2: Clone commands and hyperlinks.
-        let commands = self.host_state.canvas.lock().unwrap().commands.clone();
-        let hyperlinks = self.host_state.hyperlinks.lock().unwrap().clone();
-        let widget_commands = self.host_state.widget_commands.lock().unwrap().clone();
-        let tex_ids: HashMap<usize, egui::TextureId> = self
-            .image_textures
-            .iter()
-            .map(|(k, v)| (*k, v.id()))
-            .collect();
-
-        let host_state = self.host_state.clone();
-        let canvas_offset = self.host_state.canvas_offset.clone();
-
-        // Phase 3: Render.
-        self.hovered_link_url = None;
-        let mut new_hovered: Option<String> = None;
-        let mut clicked_link: Option<String> = None;
-
-        egui::CentralPanel::default().show(ctx, |ui| {
-            if commands.is_empty() && widget_commands.is_empty() {
-                ui.vertical_centered(|ui| {
-                    ui.add_space(ui.available_height() / 3.0);
-                    ui.heading(
-                        egui::RichText::new("Oxide Browser")
-                            .size(32.0)
-                            .color(egui::Color32::from_rgb(180, 120, 255)),
-                    );
-                    ui.label(
-                        egui::RichText::new("A binary-first browser for WebAssembly applications")
-                            .size(14.0)
-                            .color(egui::Color32::GRAY),
-                    );
-                    ui.add_space(8.0);
-                    ui.label(
-                        egui::RichText::new(
-                            "Enter a .wasm URL above or open a local file to get started.",
-                        )
-                        .color(egui::Color32::from_rgb(140, 140, 140)),
-                    );
-                });
-                return;
-            }
-
-            let available = ui.available_size();
-            let (response, painter) = ui.allocate_painter(available, egui::Sense::click());
-            let rect = response.rect;
-
-            *canvas_offset.lock().unwrap() = (rect.min.x, rect.min.y);
-
-            // ── Draw commands ───────────────────────────────────────
-            for cmd in &commands {
-                match cmd {
-                    DrawCommand::Clear { r, g, b, a } => {
-                        painter.rect_filled(
-                            rect,
-                            0.0,
-                            egui::Color32::from_rgba_unmultiplied(*r, *g, *b, *a),
-                        );
-                    }
-                    DrawCommand::Rect {
-                        x,
-                        y,
-                        w,
-                        h,
-                        r,
-                        g,
-                        b,
-                        a,
-                    } => {
-                        let min = rect.min + egui::vec2(*x, *y);
-                        let r2 = egui::Rect::from_min_size(min, egui::vec2(*w, *h));
-                        painter.rect_filled(
-                            r2,
-                            0.0,
-                            egui::Color32::from_rgba_unmultiplied(*r, *g, *b, *a),
-                        );
-                    }
-                    DrawCommand::Circle {
-                        cx,
-                        cy,
-                        radius,
-                        r,
-                        g,
-                        b,
-                        a,
-                    } => {
-                        let center = rect.min + egui::vec2(*cx, *cy);
-                        painter.circle_filled(
-                            center,
-                            *radius,
-                            egui::Color32::from_rgba_unmultiplied(*r, *g, *b, *a),
-                        );
-                    }
-                    DrawCommand::Text {
-                        x,
-                        y,
-                        size,
-                        r,
-                        g,
-                        b,
-                        text,
-                    } => {
-                        let pos = rect.min + egui::vec2(*x, *y);
-                        painter.text(
-                            pos,
-                            egui::Align2::LEFT_TOP,
-                            text,
-                            egui::FontId::proportional(*size),
-                            egui::Color32::from_rgb(*r, *g, *b),
-                        );
-                    }
-                    DrawCommand::Line {
-                        x1,
-                        y1,
-                        x2,
-                        y2,
-                        r,
-                        g,
-                        b,
-                        thickness,
-                    } => {
-                        let p1 = rect.min + egui::vec2(*x1, *y1);
-                        let p2 = rect.min + egui::vec2(*x2, *y2);
-                        painter.line_segment(
-                            [p1, p2],
-                            egui::Stroke::new(*thickness, egui::Color32::from_rgb(*r, *g, *b)),
-                        );
-                    }
-                    DrawCommand::Image {
-                        x,
-                        y,
-                        w,
-                        h,
-                        image_id,
-                    } => {
-                        if let Some(tex_id) = tex_ids.get(image_id) {
-                            let img_rect = egui::Rect::from_min_size(
-                                rect.min + egui::vec2(*x, *y),
-                                egui::vec2(*w, *h),
-                            );
-                            let uv = egui::Rect::from_min_max(
-                                egui::pos2(0.0, 0.0),
-                                egui::pos2(1.0, 1.0),
-                            );
-                            painter.image(*tex_id, img_rect, uv, egui::Color32::WHITE);
-                        }
-                    }
-                }
-            }
-
-            // ── Interactive widgets ─────────────────────────────────
-            if !widget_commands.is_empty() {
-                let mut widget_states = host_state.widget_states.lock().unwrap();
-                let mut widget_clicked = host_state.widget_clicked.lock().unwrap();
-
-                for cmd in &widget_commands {
-                    match cmd {
-                        WidgetCommand::Button {
-                            id,
-                            x,
-                            y,
-                            w,
-                            h,
-                            label,
-                        } => {
-                            let wr = egui::Rect::from_min_size(
-                                rect.min + egui::vec2(*x, *y),
-                                egui::vec2(*w, *h),
-                            );
-                            if ui.put(wr, egui::Button::new(label.as_str())).clicked() {
-                                widget_clicked.insert(*id);
-                            }
-                        }
-                        WidgetCommand::Checkbox { id, x, y, label } => {
-                            let mut checked = match widget_states.get(id) {
-                                Some(WidgetValue::Bool(b)) => *b,
-                                _ => false,
-                            };
-                            let wr = egui::Rect::from_min_size(
-                                rect.min + egui::vec2(*x, *y),
-                                egui::vec2(250.0, 24.0),
-                            );
-                            if ui
-                                .put(wr, egui::Checkbox::new(&mut checked, label.as_str()))
-                                .changed()
-                            {
-                                widget_states.insert(*id, WidgetValue::Bool(checked));
-                            }
-                        }
-                        WidgetCommand::Slider {
-                            id,
-                            x,
-                            y,
-                            w,
-                            min,
-                            max,
-                        } => {
-                            let mut value = match widget_states.get(id) {
-                                Some(WidgetValue::Float(v)) => *v,
-                                _ => *min,
-                            };
-                            let wr = egui::Rect::from_min_size(
-                                rect.min + egui::vec2(*x, *y),
-                                egui::vec2(*w, 24.0),
-                            );
-                            if ui
-                                .put(wr, egui::Slider::new(&mut value, *min..=*max))
-                                .changed()
-                            {
-                                widget_states.insert(*id, WidgetValue::Float(value));
-                            }
-                        }
-                        WidgetCommand::TextInput { id, x, y, w } => {
-                            let mut text = match widget_states.get(id) {
-                                Some(WidgetValue::Text(t)) => t.clone(),
-                                _ => String::new(),
-                            };
-                            let wr = egui::Rect::from_min_size(
-                                rect.min + egui::vec2(*x, *y),
-                                egui::vec2(*w, 24.0),
-                            );
-                            let te = egui::TextEdit::singleline(&mut text)
-                                .desired_width(*w)
-                                .id(egui::Id::new(("oxide_text_input", *id)));
-                            if ui.put(wr, te).changed() {
-                                widget_states.insert(*id, WidgetValue::Text(text));
-                            }
-                        }
-                    }
-                }
-            }
-
-            // ── Hyperlink underlines ────────────────────────────────
-            for link in &hyperlinks {
-                let link_rect = egui::Rect::from_min_size(
-                    rect.min + egui::vec2(link.x, link.y),
-                    egui::vec2(link.w, link.h),
-                );
-                painter.line_segment(
-                    [link_rect.left_bottom(), link_rect.right_bottom()],
-                    egui::Stroke::new(
-                        1.0,
-                        egui::Color32::from_rgba_unmultiplied(120, 140, 255, 80),
-                    ),
-                );
-            }
-
-            // ── Hyperlink hover / click detection ───────────────────
-            if let Some(pointer_pos) = response.hover_pos() {
-                for link in &hyperlinks {
-                    let link_rect = egui::Rect::from_min_size(
-                        rect.min + egui::vec2(link.x, link.y),
-                        egui::vec2(link.w, link.h),
-                    );
-                    if link_rect.contains(pointer_pos) {
-                        ctx.set_cursor_icon(egui::CursorIcon::PointingHand);
-                        new_hovered = Some(link.url.clone());
-
-                        painter.rect_filled(
-                            link_rect,
-                            0.0,
-                            egui::Color32::from_rgba_unmultiplied(120, 140, 255, 30),
-                        );
-
-                        if response.clicked() {
-                            clicked_link = Some(link.url.clone());
-                        }
-                        break;
-                    }
-                }
-            }
-        });
-
-        self.hovered_link_url = new_hovered;
-        if let Some(url) = clicked_link {
-            self.navigate_to(url, true);
-        }
-    }
-
-    fn render_video_pip(&mut self, ctx: &egui::Context) {
+    fn refresh_pip_texture(&mut self, window: &mut Window) {
         let pip = self.host_state.video.lock().unwrap().pip;
         if !pip {
-            self.pip_texture = None;
+            if let Some(old) = self.pip_texture.take() {
+                let _ = window.drop_image(old);
+            }
             self.pip_last_serial = 0;
             return;
         }
@@ -818,85 +280,179 @@ impl TabState {
         let serial = *self.host_state.video_pip_serial.lock().unwrap();
         if serial != self.pip_last_serial {
             self.pip_last_serial = serial;
+            if let Some(old) = self.pip_texture.take() {
+                let _ = window.drop_image(old);
+            }
             let frame = self.host_state.video_pip_frame.lock().unwrap().clone();
             if let Some(decoded) = frame {
-                let color_image = egui::ColorImage::from_rgba_unmultiplied(
-                    [decoded.width as usize, decoded.height as usize],
-                    &decoded.pixels,
-                );
-                let tex = ctx.load_texture(
+                self.pip_texture = Some(decoded_to_render_image(
+                    &decoded,
                     format!("oxide_pip_{}_{}", self.id, serial),
-                    color_image,
-                    egui::TextureOptions::LINEAR,
-                );
-                self.pip_texture = Some(tex);
+                ));
             }
         }
-
-        let Some(tex) = self.pip_texture.as_ref() else {
-            return;
-        };
-        let size = tex.size_vec2();
-        let margin = egui::vec2(16.0, 16.0);
-        let br = ctx.screen_rect().right_bottom() - margin;
-        egui::Window::new("Picture in picture")
-            .resizable(true)
-            .default_pos(br - egui::vec2(320.0, 200.0))
-            .default_size(egui::vec2(320.0, 200.0))
-            .show(ctx, |ui| {
-                ui.image((tex.id(), size));
-            });
-    }
-
-    fn render_console(&mut self, ctx: &egui::Context) {
-        egui::TopBottomPanel::bottom("console")
-            .resizable(true)
-            .default_height(160.0)
-            .show(ctx, |ui| {
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Console").strong());
-                    if ui.small_button("Clear").clicked() {
-                        self.host_state.console.lock().unwrap().clear();
-                    }
-                });
-                ui.separator();
-
-                egui::ScrollArea::vertical()
-                    .stick_to_bottom(true)
-                    .auto_shrink([false; 2])
-                    .show(ui, |ui| {
-                        let entries = self.host_state.console.lock().unwrap().clone();
-                        for entry in &entries {
-                            let color = match entry.level {
-                                ConsoleLevel::Log => egui::Color32::from_rgb(200, 200, 200),
-                                ConsoleLevel::Warn => egui::Color32::from_rgb(240, 200, 60),
-                                ConsoleLevel::Error => egui::Color32::from_rgb(240, 70, 70),
-                            };
-                            ui.horizontal(|ui| {
-                                ui.label(
-                                    egui::RichText::new(&entry.timestamp)
-                                        .monospace()
-                                        .color(egui::Color32::from_rgb(100, 100, 100))
-                                        .size(11.0),
-                                );
-                                ui.label(
-                                    egui::RichText::new(&entry.message)
-                                        .monospace()
-                                        .color(color)
-                                        .size(12.0),
-                                );
-                            });
-                        }
-                    });
-            });
     }
 }
 
-// ── Application ─────────────────────────────────────────────────────────────
+/// Decode RGBA guest bytes into a GPU [`RenderImage`] (BGRA upload for the renderer).
+fn decoded_to_render_image(
+    decoded: &crate::capabilities::DecodedImage,
+    _debug_label: String,
+) -> Arc<RenderImage> {
+    let mut buf = image::RgbaImage::from_raw(decoded.width, decoded.height, decoded.pixels.clone())
+        .expect("decoded image dimensions");
+    for pixel in buf.chunks_exact_mut(4) {
+        pixel.swap(0, 2);
+    }
+    let frame = Frame::new(buf);
+    Arc::new(RenderImage::new(smallvec![frame]))
+}
 
-/// Main [`eframe::App`] implementation: owns tab state, bookmarks, and browser chrome (navigation,
-/// panels, and dialogs) for the Oxide desktop shell.
-pub struct OxideApp {
+fn rgba8(r: u8, g: u8, b: u8, a: u8) -> gpui::Hsla {
+    gpui::Hsla::from(Rgba {
+        r: r as f32 / 255.0,
+        g: g as f32 / 255.0,
+        b: b as f32 / 255.0,
+        a: a as f32 / 255.0,
+    })
+}
+
+/// Solid text color from sRGB bytes (GPUI `TextRun` uses [`Hsla`]).
+fn text_rgb_u8(r: u8, g: u8, b: u8) -> gpui::Hsla {
+    gpui::Hsla::from(gpui::rgb(
+        ((r as u32) << 16) | ((g as u32) << 8) | (b as u32),
+    ))
+}
+
+fn circle_polygon(cx: f32, cy: f32, radius: f32) -> Vec<Point<Pixels>> {
+    let n = 48;
+    (0..n)
+        .map(|i| {
+            let t = i as f32 / n as f32 * std::f32::consts::TAU;
+            point(px(cx + radius * t.cos()), px(cy + radius * t.sin()))
+        })
+        .collect()
+}
+
+fn paint_draw_commands(
+    window: &mut Window,
+    cx: &mut gpui::App,
+    bounds: Bounds<Pixels>,
+    cmds: &[DrawCommand],
+    textures: &HashMap<usize, Arc<RenderImage>>,
+) {
+    let rect = bounds;
+    for cmd in cmds {
+        match cmd {
+            DrawCommand::Clear { r, g, b, a } => {
+                window.paint_quad(gpui::fill(rect, rgba8(*r, *g, *b, *a)));
+            }
+            DrawCommand::Rect {
+                x,
+                y,
+                w,
+                h,
+                r,
+                g,
+                b,
+                a,
+            } => {
+                let min = rect.origin + point(px(*x), px(*y));
+                window.paint_quad(gpui::fill(
+                    Bounds::from_corners(min, min + point(px(*w), px(*h))),
+                    rgba8(*r, *g, *b, *a),
+                ));
+            }
+            DrawCommand::Circle {
+                cx,
+                cy,
+                radius,
+                r,
+                g,
+                b,
+                a,
+            } => {
+                let pts = circle_polygon(
+                    f32::from(rect.origin.x) + *cx,
+                    f32::from(rect.origin.y) + *cy,
+                    *radius,
+                );
+                let mut pb = PathBuilder::fill();
+                pb.add_polygon(&pts, true);
+                if let Ok(path) = pb.build() {
+                    window.paint_path(path, rgba8(*r, *g, *b, *a));
+                }
+            }
+            DrawCommand::Text {
+                x,
+                y,
+                size,
+                r,
+                g,
+                b,
+                text,
+            } => {
+                let origin = rect.origin + point(px(*x), px(*y));
+                let text_owned = text.clone();
+                let run = TextRun {
+                    len: text_owned.len(),
+                    font: font(".SystemUIFont"),
+                    color: text_rgb_u8(*r, *g, *b),
+                    background_color: None,
+                    underline: None,
+                    strikethrough: None,
+                };
+                let line = window.text_system().shape_line(
+                    SharedString::from(text_owned),
+                    px(*size),
+                    &[run],
+                    None,
+                );
+                let _ = line.paint(origin, px(*size * 1.2), window, cx);
+            }
+            DrawCommand::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                r,
+                g,
+                b,
+                thickness,
+            } => {
+                let p1 = rect.origin + point(px(*x1), px(*y1));
+                let p2 = rect.origin + point(px(*x2), px(*y2));
+                let mut pb = PathBuilder::stroke(px(*thickness));
+                pb.move_to(p1);
+                pb.line_to(p2);
+                if let Ok(path) = pb.build() {
+                    window.paint_path(path, rgba8(*r, *g, *b, 255));
+                }
+            }
+            DrawCommand::Image {
+                x,
+                y,
+                w,
+                h,
+                image_id,
+            } => {
+                if let Some(tex) = textures.get(image_id) {
+                    let min = rect.origin + point(px(*x), px(*y));
+                    let img_bounds = Bounds::from_corners(min, min + point(px(*w), px(*h)));
+                    let _ = window.paint_image(img_bounds, (0.).into(), tex.clone(), 0, false);
+                }
+            }
+        }
+    }
+}
+
+/// Result of a background `rfd` file dialog (must not run inside GPUI `App::update` — modal + focus events re-enter and panic).
+enum FilePickDone {
+    Chosen { path: PathBuf, bytes: Vec<u8> },
+    Cancelled,
+}
+
+pub struct OxideBrowserView {
     tabs: Vec<TabState>,
     active_tab: usize,
     next_tab_id: u64,
@@ -905,16 +461,19 @@ pub struct OxideApp {
     bookmark_store: Option<BookmarkStore>,
     show_bookmarks: bool,
     show_about: bool,
+    /// Focus for the page (canvas + guest widgets); required for keyboard to reach `on_key_down` on the root.
+    canvas_focus: FocusHandle,
+    url_focus: FocusHandle,
+    /// Receiver for [`FilePickDone`]; dialog runs on a background thread so the main thread never holds `App` during `NSOpenPanel`.
+    file_pick_rx: Option<mpsc::Receiver<FilePickDone>>,
 }
 
-impl OxideApp {
-    pub fn new(host_state: HostState, status: Arc<Mutex<PageStatus>>) -> Self {
+impl OxideBrowserView {
+    fn new(cx: &mut Context<Self>, host_state: HostState, status: Arc<Mutex<PageStatus>>) -> Self {
         let shared_kv_db = host_state.kv_db.clone();
         let shared_module_loader = host_state.module_loader.clone();
         let bookmark_store = host_state.bookmark_store.lock().unwrap().clone();
-
         let first_tab = TabState::new(0, host_state, status);
-
         Self {
             tabs: vec![first_tab],
             active_tab: 0,
@@ -924,6 +483,31 @@ impl OxideApp {
             bookmark_store,
             show_bookmarks: false,
             show_about: false,
+            canvas_focus: cx.focus_handle(),
+            url_focus: cx.focus_handle(),
+            file_pick_rx: None,
+        }
+    }
+
+    fn poll_file_pick(&mut self, cx: &mut Context<Self>) {
+        let rx = match self.file_pick_rx.take() {
+            Some(r) => r,
+            None => return,
+        };
+        match rx.try_recv() {
+            Ok(FilePickDone::Chosen { path, bytes }) => {
+                let file_url = format!("file://{}", path.display());
+                let tab = &mut self.tabs[self.active_tab];
+                tab.url_input = file_url.clone();
+                tab.pending_history_url = Some(file_url);
+                let _ = tab.run_tx.send(RunRequest::LoadLocal(bytes));
+                cx.notify();
+            }
+            Ok(FilePickDone::Cancelled) => {}
+            Err(TryRecvError::Empty) => {
+                self.file_pick_rx = Some(rx);
+            }
+            Err(TryRecvError::Disconnected) => {}
         }
     }
 
@@ -943,58 +527,30 @@ impl OxideApp {
         self.tabs.len() - 1
     }
 
+    /// Keep `active_tab` in range. Stale close handlers can fire with an old tab index after the strip shrinks.
+    fn clamp_active_tab(&mut self) {
+        if self.tabs.is_empty() {
+            self.active_tab = 0;
+            return;
+        }
+        self.active_tab = self.active_tab.min(self.tabs.len() - 1);
+    }
+
     fn close_tab(&mut self, idx: usize) {
         if self.tabs.len() <= 1 {
             return;
         }
+        if idx >= self.tabs.len() {
+            self.clamp_active_tab();
+            return;
+        }
         self.tabs.remove(idx);
-        if self.active_tab == idx {
-            if self.active_tab >= self.tabs.len() {
-                self.active_tab = self.tabs.len() - 1;
-            }
-        } else if self.active_tab > idx {
+        if self.active_tab > idx {
             self.active_tab -= 1;
+        } else if self.active_tab == idx && self.active_tab >= self.tabs.len() {
+            self.active_tab = self.tabs.len().saturating_sub(1);
         }
-    }
-
-    fn handle_keyboard_shortcuts(&mut self, ctx: &egui::Context) {
-        let (new_tab, close_tab, next_tab, prev_tab, toggle_bookmark, toggle_panel) =
-            ctx.input(|i| {
-                let cmd = i.modifiers.command;
-                (
-                    cmd && i.key_pressed(egui::Key::T),
-                    cmd && i.key_pressed(egui::Key::W),
-                    i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::Tab),
-                    i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Tab),
-                    cmd && i.key_pressed(egui::Key::D),
-                    cmd && i.key_pressed(egui::Key::B),
-                )
-            });
-
-        if new_tab {
-            let idx = self.create_tab();
-            self.active_tab = idx;
-        }
-        if close_tab && self.tabs.len() > 1 {
-            let active = self.active_tab;
-            self.close_tab(active);
-        }
-        if next_tab && !self.tabs.is_empty() {
-            self.active_tab = (self.active_tab + 1) % self.tabs.len();
-        }
-        if prev_tab && !self.tabs.is_empty() {
-            if self.active_tab == 0 {
-                self.active_tab = self.tabs.len() - 1;
-            } else {
-                self.active_tab -= 1;
-            }
-        }
-        if toggle_bookmark {
-            self.toggle_active_bookmark();
-        }
-        if toggle_panel {
-            self.show_bookmarks = !self.show_bookmarks;
-        }
+        self.clamp_active_tab();
     }
 
     fn toggle_active_bookmark(&self) {
@@ -1013,437 +569,1050 @@ impl OxideApp {
     }
 }
 
-impl eframe::App for OxideApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.handle_keyboard_shortcuts(ctx);
-
-        // Drain results and handle navigations for all tabs so background loads complete.
+impl Render for OxideBrowserView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.clamp_active_tab();
+        self.poll_file_pick(cx);
         for tab in &mut self.tabs {
             tab.drain_results();
             tab.handle_pending_navigation();
             tab.sync_url_bar();
         }
 
-        ctx.request_repaint();
-
         let active = self.active_tab;
-        self.tabs[active].capture_input(ctx);
-        self.tabs[active].tick_frame();
+        {
+            let tab = &mut self.tabs[active];
+            tab.sync_keys_held_to_input();
+            tab.tick_frame();
+            tab.update_texture_cache(window);
+            tab.refresh_pip_texture(window);
+        }
 
-        self.render_tab_bar(ctx);
+        let canvas_offset = self.tabs[active].host_state.canvas_offset.clone();
+        let cmds = self.tabs[active]
+            .host_state
+            .canvas
+            .lock()
+            .unwrap()
+            .commands
+            .clone();
+        let hyperlinks = self.tabs[active]
+            .host_state
+            .hyperlinks
+            .lock()
+            .unwrap()
+            .clone();
+        let hyperlinks_hover = hyperlinks.clone();
+        let widget_commands = self.tabs[active]
+            .host_state
+            .widget_commands
+            .lock()
+            .unwrap()
+            .clone();
+        let widget_cmds_overlay = widget_commands.clone();
+        let textures = self.tabs[active].image_textures.clone();
+        let show_console = self.tabs[active].show_console;
+        let pip_tex = self.tabs[active].pip_texture.clone();
 
-        let bm_store = self.bookmark_store.clone();
-        let mut show_bm = self.show_bookmarks;
-        let mut show_about = self.show_about;
-        self.tabs[self.active_tab].render_toolbar(ctx, &bm_store, &mut show_bm, &mut show_about);
-        self.show_bookmarks = show_bm;
-        self.show_about = show_about;
+        self.tabs[active].post_tick_clear_input();
 
-        let mut nav_to_url: Option<String> = None;
+        cx.on_next_frame(window, |_this, _window, cx| {
+            cx.notify();
+        });
+
+        let tab_titles: Vec<String> = self.tabs.iter().map(|t| t.display_title()).collect();
+        let num_tabs = self.tabs.len();
+        let active_tab = self.active_tab;
+        let bm = self.bookmark_store.clone();
+        let current_url = self.tabs[active].url_input.clone();
+        let is_bookmarked = bm
+            .as_ref()
+            .map(|s| s.contains(&current_url))
+            .unwrap_or(false);
+        let url_bar_text = SharedString::from(current_url);
+        let can_back = self.tabs[active]
+            .host_state
+            .navigation
+            .lock()
+            .unwrap()
+            .can_go_back();
+        let _can_fwd = self.tabs[active]
+            .host_state
+            .navigation
+            .lock()
+            .unwrap()
+            .can_go_forward();
+
+        let mut root = div()
+            .id("oxide_root")
+            .track_focus(&self.canvas_focus)
+            .focusable()
+            .size_full()
+            .flex()
+            .flex_col()
+            .bg(gpui::rgb(0x1a1a20))
+            .on_key_down(cx.listener(
+                |this: &mut OxideBrowserView, event: &KeyDownEvent, window, cx| {
+                    {
+                        let tab = &this.tabs[this.active_tab];
+                        let mut input = tab.host_state.input_state.lock().unwrap();
+                        input.modifiers_shift = event.keystroke.modifiers.shift;
+                        input.modifiers_ctrl =
+                            event.keystroke.modifiers.control || event.keystroke.modifiers.platform;
+                        input.modifiers_alt = event.keystroke.modifiers.alt;
+                    }
+                    if event.keystroke.modifiers.secondary() && event.keystroke.key == "t" {
+                        let i = this.create_tab();
+                        this.active_tab = i;
+                        cx.notify();
+                        return;
+                    }
+                    if event.keystroke.modifiers.secondary() && event.keystroke.key == "w" {
+                        if this.tabs.len() > 1 {
+                            let a = this.active_tab;
+                            this.close_tab(a);
+                        }
+                        cx.notify();
+                        return;
+                    }
+                    if event.keystroke.modifiers.control
+                        && !event.keystroke.modifiers.shift
+                        && event.keystroke.key == "tab"
+                    {
+                        if !this.tabs.is_empty() {
+                            this.active_tab = (this.active_tab + 1) % this.tabs.len();
+                        }
+                        cx.notify();
+                        return;
+                    }
+                    if event.keystroke.modifiers.control
+                        && event.keystroke.modifiers.shift
+                        && event.keystroke.key == "tab"
+                    {
+                        if !this.tabs.is_empty() {
+                            if this.active_tab == 0 {
+                                this.active_tab = this.tabs.len() - 1;
+                            } else {
+                                this.active_tab -= 1;
+                            }
+                        }
+                        cx.notify();
+                        return;
+                    }
+                    if event.keystroke.modifiers.secondary() && event.keystroke.key == "d" {
+                        this.toggle_active_bookmark();
+                        cx.notify();
+                        return;
+                    }
+                    if event.keystroke.modifiers.secondary() && event.keystroke.key == "b" {
+                        this.show_bookmarks = !this.show_bookmarks;
+                        cx.notify();
+                        return;
+                    }
+                    if this.url_focus.is_focused(window) {
+                        return;
+                    }
+                    if let Some(id) = this.tabs[this.active_tab].text_input_focus {
+                        let mut states = this.tabs[this.active_tab]
+                            .host_state
+                            .widget_states
+                            .lock()
+                            .unwrap();
+                        let mut text = match states.get(&id) {
+                            Some(WidgetValue::Text(t)) => t.clone(),
+                            _ => String::new(),
+                        };
+                        if event.keystroke.key == "backspace" {
+                            text.pop();
+                        } else if let Some(s) = text_insert_from_keystroke(&event.keystroke) {
+                            text.push_str(&s);
+                        }
+                        states.insert(id, WidgetValue::Text(text));
+                        cx.notify();
+                        return;
+                    }
+                    if let Some(code) = keystroke_to_oxide(&event.keystroke) {
+                        let tab = &mut this.tabs[this.active_tab];
+                        tab.keys_held.insert(code);
+                        tab.host_state
+                            .input_state
+                            .lock()
+                            .unwrap()
+                            .keys_pressed
+                            .push(code);
+                        cx.notify();
+                    }
+                },
+            ))
+            .on_key_up(cx.listener(|this, event: &KeyUpEvent, _, _cx| {
+                let tab = &mut this.tabs[this.active_tab];
+                {
+                    let mut input = tab.host_state.input_state.lock().unwrap();
+                    input.modifiers_shift = event.keystroke.modifiers.shift;
+                    input.modifiers_ctrl =
+                        event.keystroke.modifiers.control || event.keystroke.modifiers.platform;
+                    input.modifiers_alt = event.keystroke.modifiers.alt;
+                }
+                if let Some(code) = keystroke_to_oxide(&event.keystroke) {
+                    tab.keys_held.remove(&code);
+                }
+            }));
+
+        // Tab strip
+        root = root.child(
+            div()
+                .h(px(40.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .px_1()
+                .border_b_1()
+                .border_color(gpui::rgb(0x2a2a32))
+                .children((0..num_tabs).map(|i| {
+                    let title = tab_titles[i].clone();
+                    let display = truncate_tab_title(&title);
+                    let is_active = i == active_tab;
+                    div()
+                        .id(("oxide_tab", i))
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .gap_1()
+                        .min_w(px(140.0))
+                        .px_3()
+                        .py_2()
+                        .rounded_md()
+                        .cursor_pointer()
+                        .when(is_active, |d| d.bg(gpui::rgb(0x373741)))
+                        .text_sm()
+                        .text_color(if is_active {
+                            gpui::rgb(0xdcdce6)
+                        } else {
+                            gpui::rgb(0x9696a0)
+                        })
+                        .child(
+                            div()
+                                .flex_1()
+                                .min_w(px(0.0))
+                                .overflow_hidden()
+                                .child(display),
+                        )
+                        .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                            this.active_tab = i;
+                            cx.notify();
+                        }))
+                        .when(num_tabs > 1, |d| {
+                            d.child(
+                                div()
+                                    .id(("oxide_tab_close", i))
+                                    .flex_shrink_0()
+                                    .cursor_pointer()
+                                    .text_color(gpui::rgb(0xa0a0aa))
+                                    .child("×")
+                                    .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                                        this.close_tab(i);
+                                        cx.notify();
+                                    })),
+                            )
+                        })
+                }))
+                .child(
+                    div()
+                        .id("oxide_new_tab")
+                        .ml_1()
+                        .cursor_pointer()
+                        .text_color(gpui::rgb(0xc0c0cc))
+                        .child("+")
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            let i = this.create_tab();
+                            this.active_tab = i;
+                            cx.notify();
+                        })),
+                ),
+        );
+
+        // Toolbar
+        let status_icon = match &*self.tabs[active].status.lock().unwrap() {
+            PageStatus::Idle => "○",
+            PageStatus::Loading(_) => "↻",
+            PageStatus::Running(_) => "●",
+            PageStatus::Error(_) => "●",
+        };
+        let status_color = match &*self.tabs[active].status.lock().unwrap() {
+            PageStatus::Error(_) => gpui::rgb(0xf05050),
+            PageStatus::Running(_) => gpui::rgb(0x50e070),
+            _ => gpui::rgb(0xa0a0a8),
+        };
+
+        root = root.child(
+            div()
+                .h(px(44.0))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .border_b_1()
+                .border_color(gpui::rgb(0x2a2a32))
+                .child(
+                    div()
+                        .id("oxide_back")
+                        .cursor_pointer()
+                        .text_sm()
+                        .text_color(gpui::rgb(0xb8b8c4))
+                        .child("◀")
+                        .when(can_back, |d| d)
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            this.tabs[this.active_tab].go_back();
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    div()
+                        .id("oxide_forward")
+                        .cursor_pointer()
+                        .text_sm()
+                        .text_color(gpui::rgb(0xb8b8c4))
+                        .child("▶")
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            this.tabs[this.active_tab].go_forward();
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    div()
+                        .text_sm()
+                        .text_color(status_color)
+                        .child(status_icon.to_string()),
+                )
+                .child(
+                    div()
+                        .id("oxide_url_bar")
+                        .flex_1()
+                        .flex()
+                        .flex_row()
+                        .items_center()
+                        .h(px(32.0))
+                        .px_2()
+                        .rounded_md()
+                        .bg(gpui::rgb(0x121218))
+                        .track_focus(&self.url_focus)
+                        .text_color(gpui::rgb(0xdcdce6))
+                        .on_key_down(cx.listener(
+                            |this: &mut OxideBrowserView, event: &KeyDownEvent, window, cx| {
+                                if !this.url_focus.is_focused(window) {
+                                    return;
+                                }
+                                let tab = &mut this.tabs[this.active_tab];
+                                if event.keystroke.key == "backspace" {
+                                    tab.url_input.pop();
+                                    cx.notify();
+                                    return;
+                                }
+                                if event.keystroke.key == "enter" {
+                                    tab.navigate();
+                                    cx.notify();
+                                    return;
+                                }
+                                if let Some(s) = text_insert_from_keystroke(&event.keystroke) {
+                                    tab.url_input.push_str(&s);
+                                    cx.notify();
+                                }
+                            },
+                        ))
+                        .child(url_bar_text),
+                )
+                .child(
+                    div()
+                        .id("oxide_bookmark")
+                        .cursor_pointer()
+                        .text_lg()
+                        .text_color(if is_bookmarked {
+                            gpui::rgb(0xffc832)
+                        } else {
+                            gpui::rgb(0xa0a0a8)
+                        })
+                        .child(if is_bookmarked { "★" } else { "☆" })
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            this.toggle_active_bookmark();
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    div()
+                        .id("oxide_open_file")
+                        .cursor_pointer()
+                        .text_sm()
+                        .text_color(gpui::rgb(0xc8c8d4))
+                        .child("Open")
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            if this.file_pick_rx.is_some() {
+                                return;
+                            }
+                            let (tx, rx) = mpsc::channel();
+                            this.file_pick_rx = Some(rx);
+                            std::thread::spawn(move || {
+                                let path = rfd::FileDialog::new()
+                                    .add_filter("WebAssembly", &["wasm"])
+                                    .set_title("Open .wasm Application")
+                                    .pick_file();
+                                let msg = match path {
+                                    Some(p) => match std::fs::read(&p) {
+                                        Ok(bytes) => FilePickDone::Chosen { path: p, bytes },
+                                        Err(_) => FilePickDone::Cancelled,
+                                    },
+                                    None => FilePickDone::Cancelled,
+                                };
+                                let _ = tx.send(msg);
+                            });
+                            cx.notify();
+                        })),
+                )
+                .child(
+                    div()
+                        .id("oxide_about_btn")
+                        .cursor_pointer()
+                        .text_sm()
+                        .text_color(gpui::rgb(0xc8c8d4))
+                        .child("About")
+                        .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                            this.show_about = !this.show_about;
+                            cx.notify();
+                        })),
+                ),
+        );
+
+        // Main row: optional bookmarks + content
+        let mut main_row = div().flex_1().flex().flex_row().min_h_0();
+
         if self.show_bookmarks {
-            nav_to_url = Self::render_bookmarks_panel(ctx, &self.bookmark_store);
+            if let Some(store) = &self.bookmark_store {
+                let items = store.list_all();
+                main_row = main_row.child(
+                    div()
+                        .id("oxide_bookmarks_panel")
+                        .w(px(260.0))
+                        .h_full()
+                        .overflow_scroll()
+                        .border_r_1()
+                        .border_color(gpui::rgb(0x2a2a32))
+                        .p_2()
+                        .children(items.iter().enumerate().map(|(bi, bm)| {
+                            let url = bm.url.clone();
+                            let label = if bm.title.is_empty() {
+                                url_to_title(&bm.url)
+                            } else {
+                                bm.title.clone()
+                            };
+                            div()
+                                .id(("oxide_bm", bi))
+                                .py_1()
+                                .cursor_pointer()
+                                .text_sm()
+                                .text_color(gpui::rgb(0xaab4ff))
+                                .child(truncate_tab_title(&label))
+                                .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                                    this.tabs[this.active_tab].navigate_to(url.clone(), true);
+                                    cx.notify();
+                                }))
+                        })),
+                );
+            }
         }
 
-        self.tabs[self.active_tab].render_canvas(ctx);
-        self.tabs[self.active_tab].render_video_pip(ctx);
+        let text_input_focus_id = self.tabs[active].text_input_focus;
+        let caret_blink_on = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| (d.as_millis() / 530) % 2 == 0)
+            .unwrap_or(true);
 
-        if self.tabs[self.active_tab].show_console {
-            self.tabs[self.active_tab].render_console(ctx);
-        }
+        let canvas_area = div()
+            .flex_1()
+            .flex()
+            .flex_col()
+            .min_h_0()
+            .relative()
+            .child({
+                let cmds = cmds.clone();
+                let textures = textures.clone();
+                let canvas_offset = canvas_offset.clone();
+                let canvas_state_for_dims = self.tabs[active].host_state.canvas.clone();
+                canvas(
+                    move |bounds, _window, _cx| {
+                        *canvas_offset.lock().unwrap() =
+                            (f32::from(bounds.origin.x), f32::from(bounds.origin.y));
+                        let mut cs = canvas_state_for_dims.lock().unwrap();
+                        cs.width = f32::from(bounds.size.width) as u32;
+                        cs.height = f32::from(bounds.size.height) as u32;
+                    },
+                    move |bounds, (), window, cx| {
+                        if cmds.is_empty() {
+                            let _ = window
+                                .text_system()
+                                .shape_line(
+                                    "Oxide Browser".into(),
+                                    px(28.0),
+                                    &[TextRun {
+                                        len: 13,
+                                        font: font(".SystemUIFont"),
+                                        color: gpui::hsla(0.75, 0.5, 0.7, 1.0),
+                                        background_color: None,
+                                        underline: None,
+                                        strikethrough: None,
+                                    }],
+                                    None,
+                                )
+                                .paint(
+                                    bounds.origin + point(px(24.0), px(24.0)),
+                                    px(32.0),
+                                    window,
+                                    cx,
+                                );
+                        } else {
+                            paint_draw_commands(window, cx, bounds, &cmds, &textures);
+                        }
+                    },
+                )
+                .flex_1()
+            })
+            .child(
+                div()
+                    .id("oxide_canvas_overlay")
+                    .absolute()
+                    .size_full()
+                    .top_0()
+                    .left_0()
+                    .on_mouse_move(cx.listener({
+                        let hyperlinks_hover = hyperlinks_hover.clone();
+                        move |this, event: &gpui::MouseMoveEvent, _, _cx| {
+                            let tab = &mut this.tabs[this.active_tab];
+                            let mut input = tab.host_state.input_state.lock().unwrap();
+                            input.mouse_x = f32::from(event.position.x);
+                            input.mouse_y = f32::from(event.position.y);
+                            drop(input);
+                            let (ox, oy) = *tab.host_state.canvas_offset.lock().unwrap();
+                            let lx = f32::from(event.position.x) - ox;
+                            let ly = f32::from(event.position.y) - oy;
+                            let mut hovered = None;
+                            for link in &hyperlinks_hover {
+                                if lx >= link.x
+                                    && ly >= link.y
+                                    && lx <= link.x + link.w
+                                    && ly <= link.y + link.h
+                                {
+                                    hovered = Some(link.url.clone());
+                                    break;
+                                }
+                            }
+                            tab.hovered_link_url = hovered;
+                        }
+                    }))
+                    .on_any_mouse_down(cx.listener(|this, event: &MouseDownEvent, _, _cx| {
+                        let tab = &mut this.tabs[this.active_tab];
+                        let mut input = tab.host_state.input_state.lock().unwrap();
+                        let b = match event.button {
+                            MouseButton::Left => 0,
+                            MouseButton::Right => 1,
+                            MouseButton::Middle => 2,
+                            _ => return,
+                        };
+                        input.mouse_buttons_down[b] = true;
+                    }))
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(|this, _: &MouseUpEvent, _, _cx| {
+                            let tab = &mut this.tabs[this.active_tab];
+                            let mut input = tab.host_state.input_state.lock().unwrap();
+                            input.mouse_buttons_down[0] = false;
+                            input.mouse_buttons_clicked[0] = true;
+                        }),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Right,
+                        cx.listener(|this, _: &MouseUpEvent, _, _cx| {
+                            let tab = &mut this.tabs[this.active_tab];
+                            let mut input = tab.host_state.input_state.lock().unwrap();
+                            input.mouse_buttons_down[1] = false;
+                            input.mouse_buttons_clicked[1] = true;
+                        }),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Middle,
+                        cx.listener(|this, _: &MouseUpEvent, _, _cx| {
+                            let tab = &mut this.tabs[this.active_tab];
+                            let mut input = tab.host_state.input_state.lock().unwrap();
+                            input.mouse_buttons_down[2] = false;
+                            input.mouse_buttons_clicked[2] = true;
+                        }),
+                    )
+                    .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
+                        if let Some(pos) = event.mouse_position() {
+                            let tab = &mut this.tabs[this.active_tab];
+                            let (ox, oy) = *tab.host_state.canvas_offset.lock().unwrap();
+                            let lx = f32::from(pos.x) - ox;
+                            let ly = f32::from(pos.y) - oy;
+                            if canvas_point_hits_widget(lx, ly, &widget_cmds_overlay) {
+                                return;
+                            }
+                            let links = tab.host_state.hyperlinks.lock().unwrap().clone();
+                            for link in links.iter().rev() {
+                                if lx >= link.x
+                                    && ly >= link.y
+                                    && lx <= link.x + link.w
+                                    && ly <= link.y + link.h
+                                {
+                                    tab.navigate_to(link.url.clone(), true);
+                                    cx.notify();
+                                    return;
+                                }
+                            }
+                            tab.text_input_focus = None;
+                            this.canvas_focus.focus(window);
+                        }
+                    }))
+                    .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _, _cx| {
+                        let tab = &mut this.tabs[this.active_tab];
+                        let mut input = tab.host_state.input_state.lock().unwrap();
+                        match event.delta {
+                            ScrollDelta::Pixels(p) => {
+                                input.scroll_x += f32::from(p.x);
+                                input.scroll_y += f32::from(p.y);
+                            }
+                            ScrollDelta::Lines(l) => {
+                                input.scroll_x += l.x * 20.0;
+                                input.scroll_y += l.y * 20.0;
+                            }
+                        }
+                    })),
+            );
 
-        if let Some(url) = nav_to_url {
-            self.tabs[self.active_tab].navigate_to(url, true);
-        }
+        let widget_states_snapshot = self.tabs[active]
+            .host_state
+            .widget_states
+            .lock()
+            .unwrap()
+            .clone();
 
-        if let Some(link_url) = self.tabs[self.active_tab].hovered_link_url.clone() {
-            egui::TopBottomPanel::bottom("link_status")
-                .default_height(18.0)
-                .show(ctx, |ui| {
-                    ui.label(
-                        egui::RichText::new(&link_url)
-                            .monospace()
-                            .size(11.0)
-                            .color(egui::Color32::from_rgb(140, 140, 180)),
-                    );
+        let canvas_with_widgets =
+            widget_commands
+                .into_iter()
+                .fold(canvas_area, |el, cmd| match cmd {
+                    WidgetCommand::Button {
+                        id,
+                        x,
+                        y,
+                        w,
+                        h,
+                        label,
+                    } => el.child(
+                        div()
+                            .id(("oxide_btn", id as usize))
+                            .absolute()
+                            .left(px(x))
+                            .top(px(y))
+                            .w(px(w))
+                            .h(px(h))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .rounded_md()
+                            .bg(gpui::rgb(0x3a3a48))
+                            .cursor_pointer()
+                            .text_sm()
+                            .text_color(gpui::rgb(0xe8e8f0))
+                            .child(label)
+                            .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                                this.tabs[this.active_tab]
+                                    .host_state
+                                    .widget_clicked
+                                    .lock()
+                                    .unwrap()
+                                    .insert(id);
+                                cx.notify();
+                            })),
+                    ),
+                    WidgetCommand::Checkbox { id, x, y, label } => {
+                        let checked = widget_states_snapshot
+                            .get(&id)
+                            .and_then(|v| match v {
+                                WidgetValue::Bool(b) => Some(*b),
+                                _ => None,
+                            })
+                            .unwrap_or(false);
+                        el.child(
+                            div()
+                                .id(("oxide_cb", id as usize))
+                                .absolute()
+                                .left(px(x))
+                                .top(px(y))
+                                .w(px(220.0))
+                                .h(px(30.0))
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .gap_2()
+                                .cursor_pointer()
+                                .on_click(cx.listener(move |this, _: &ClickEvent, _, cx| {
+                                    let mut states = this.tabs[this.active_tab]
+                                        .host_state
+                                        .widget_states
+                                        .lock()
+                                        .unwrap();
+                                    let cur = states
+                                        .get(&id)
+                                        .and_then(|v| match v {
+                                            WidgetValue::Bool(b) => Some(*b),
+                                            _ => None,
+                                        })
+                                        .unwrap_or(false);
+                                    states.insert(id, WidgetValue::Bool(!cur));
+                                    cx.notify();
+                                }))
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .text_color(gpui::rgb(0xa0a0aa))
+                                        .child(if checked { "☑" } else { "☐" }),
+                                )
+                                .child(
+                                    div().text_sm().text_color(gpui::rgb(0xd0d0dc)).child(label),
+                                ),
+                        )
+                    }
+                    WidgetCommand::Slider {
+                        id,
+                        x,
+                        y,
+                        w,
+                        min,
+                        max,
+                    } => {
+                        let cur = widget_states_snapshot
+                            .get(&id)
+                            .and_then(|v| match v {
+                                WidgetValue::Float(f) => Some(*f),
+                                _ => None,
+                            })
+                            .unwrap_or(min);
+                        el.child(
+                            div()
+                                .id(("oxide_sl", id as usize))
+                                .absolute()
+                                .left(px(x))
+                                .top(px(y))
+                                .w(px(w))
+                                .h(px(28.0))
+                                .flex()
+                                .items_center()
+                                .rounded_md()
+                                .bg(gpui::rgb(0x2a2a32))
+                                .on_click(cx.listener(move |this, event: &ClickEvent, _, cx| {
+                                    if let Some(pos) = event.mouse_position() {
+                                        let tab = &mut this.tabs[this.active_tab];
+                                        let (ox, _) = *tab.host_state.canvas_offset.lock().unwrap();
+                                        let lx = f32::from(pos.x) - ox;
+                                        let frac = ((lx - x) / w).clamp(0.0, 1.0);
+                                        let v = min + frac * (max - min);
+                                        tab.host_state
+                                            .widget_states
+                                            .lock()
+                                            .unwrap()
+                                            .insert(id, WidgetValue::Float(v));
+                                        cx.notify();
+                                    }
+                                }))
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(gpui::rgb(0xb0b0c0))
+                                        .child(format!("{cur:.1}")),
+                                ),
+                        )
+                    }
+                    WidgetCommand::TextInput { id, x, y, w } => {
+                        let value = widget_states_snapshot
+                            .get(&id)
+                            .and_then(|v| match v {
+                                WidgetValue::Text(t) => Some(t.clone()),
+                                _ => None,
+                            })
+                            .unwrap_or_default();
+                        let show_caret = text_input_focus_id == Some(id) && caret_blink_on;
+                        el.child(
+                            div()
+                                .id(("oxide_ti", id as usize))
+                                .absolute()
+                                .left(px(x))
+                                .top(px(y))
+                                .w(px(w))
+                                .h(px(28.0))
+                                .px_2()
+                                .rounded_md()
+                                .bg(gpui::rgb(0x121218))
+                                .border_1()
+                                .border_color(if text_input_focus_id == Some(id) {
+                                    gpui::rgb(0x6a6a8a)
+                                } else {
+                                    gpui::rgb(0x3a3a48)
+                                })
+                                .cursor_pointer()
+                                .flex()
+                                .flex_row()
+                                .items_center()
+                                .justify_start()
+                                .gap_1()
+                                .min_w_0()
+                                .child(
+                                    div()
+                                        .flex_initial()
+                                        .min_w_0()
+                                        .overflow_hidden()
+                                        .text_sm()
+                                        .text_color(gpui::rgb(0xe4e4ec))
+                                        .child(SharedString::from(value)),
+                                )
+                                .when(show_caret, |d| {
+                                    d.child(
+                                        div()
+                                            .flex_shrink_0()
+                                            .w(px(2.0))
+                                            .h(px(16.0))
+                                            .mt(px(1.0))
+                                            .rounded_sm()
+                                            .bg(gpui::rgb(0xe8e8f0)),
+                                    )
+                                })
+                                .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
+                                    this.tabs[this.active_tab].text_input_focus = Some(id);
+                                    this.canvas_focus.focus(window);
+                                    cx.notify();
+                                })),
+                        )
+                    }
                 });
+
+        let mut content_col = div().flex_1().flex().flex_col().min_h_0();
+        content_col = content_col.child(canvas_with_widgets);
+
+        if let Some(tex) = pip_tex {
+            content_col = content_col.child(
+                div()
+                    .id("oxide_pip")
+                    .absolute()
+                    .bottom(px(16.0))
+                    .right(px(16.0))
+                    .w(px(320.0))
+                    .h(px(200.0))
+                    .rounded_md()
+                    .overflow_hidden()
+                    .border_1()
+                    .border_color(gpui::rgb(0x2a2a32))
+                    .child(img(ImageSource::from(tex)).object_fit(gpui::ObjectFit::Contain)),
+            );
+        }
+
+        if show_console {
+            let entries = self.tabs[active].host_state.console.lock().unwrap().clone();
+            content_col = content_col.child(
+                div()
+                    .id("oxide_console")
+                    .h(px(160.0))
+                    .border_t_1()
+                    .border_color(gpui::rgb(0x2a2a32))
+                    .overflow_scroll()
+                    .p_2()
+                    .font_family("Monaco")
+                    .text_xs()
+                    .children(entries.into_iter().map(|e| {
+                        let color = match e.level {
+                            ConsoleLevel::Log => gpui::rgb(0xc8c8c8),
+                            ConsoleLevel::Warn => gpui::rgb(0xf0c83c),
+                            ConsoleLevel::Error => gpui::rgb(0xf05050),
+                        };
+                        div()
+                            .flex()
+                            .flex_row()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .text_color(gpui::rgb(0x646464))
+                                    .child(e.timestamp.clone()),
+                            )
+                            .child(div().text_color(color).child(e.message.clone()))
+                    })),
+            );
+        }
+
+        main_row = main_row.child(content_col);
+
+        root = root.child(main_row);
+
+        if let Some(url) = self.tabs[active].hovered_link_url.clone() {
+            root = root.child(
+                div()
+                    .id("oxide_link_status")
+                    .h(px(18.0))
+                    .border_t_1()
+                    .border_color(gpui::rgb(0x2a2a32))
+                    .px_2()
+                    .font_family("Monaco")
+                    .text_xs()
+                    .text_color(gpui::rgb(0x8c8cb4))
+                    .child(url),
+            );
         }
 
         if self.show_about {
-            self.render_about_modal(ctx);
+            root = root.child(
+                div()
+                    .id("oxide_about_scrim")
+                    .absolute()
+                    .size_full()
+                    .top_0()
+                    .left_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(gpui::hsla(0., 0., 0., 0.5))
+                    .on_click(cx.listener(|this, _: &ClickEvent, _, cx| {
+                        this.show_about = false;
+                        cx.notify();
+                    }))
+                    .child(
+                        div()
+                            .id("oxide_about_card")
+                            .w(px(360.0))
+                            .p_4()
+                            .rounded_lg()
+                            .bg(gpui::rgb(0x222228))
+                            .on_click(|_, _, _| {})
+                            .child(
+                                div()
+                                    .text_lg()
+                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .text_color(gpui::rgb(0xb478ff))
+                                    .child("Oxide Browser"),
+                            )
+                            .child(
+                                div()
+                                    .mt_2()
+                                    .text_sm()
+                                    .text_color(gpui::rgb(0xa0a0a8))
+                                    .child(format!("Version {}", env!("CARGO_PKG_VERSION"))),
+                            )
+                            .child(
+                                div()
+                                    .mt_2()
+                                    .text_sm()
+                                    .child("GPU-accelerated UI (GPUI) · Wasmtime sandbox"),
+                            ),
+                    ),
+            );
         }
+
+        root
     }
 }
 
-impl OxideApp {
-    fn render_about_modal(&mut self, ctx: &egui::Context) {
-        egui::Window::new("About Oxide")
-            .collapsible(false)
-            .resizable(false)
-            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-            .fixed_size([360.0, 0.0])
-            .show(ctx, |ui| {
-                ui.vertical_centered(|ui| {
-                    ui.add_space(8.0);
-                    ui.heading(
-                        egui::RichText::new("Oxide Browser")
-                            .size(24.0)
-                            .strong()
-                            .color(egui::Color32::from_rgb(180, 120, 255)),
-                    );
-                    ui.add_space(4.0);
-                    ui.label(
-                        egui::RichText::new(format!("Version {}", env!("CARGO_PKG_VERSION")))
-                            .size(13.0)
-                            .color(egui::Color32::from_rgb(160, 160, 170)),
-                    );
-                    ui.add_space(12.0);
-                });
-
-                ui.label("A binary-first, decentralized browser that loads and runs WebAssembly modules instead of HTML/JavaScript.");
-                ui.add_space(8.0);
-
-                egui::Grid::new("about_details")
-                    .num_columns(2)
-                    .spacing([12.0, 4.0])
-                    .show(ui, |ui| {
-                        ui.label(
-                            egui::RichText::new("Runtime")
-                                .strong()
-                                .color(egui::Color32::from_rgb(180, 180, 190)),
-                        );
-                        ui.label("Wasmtime");
-                        ui.end_row();
-
-                        ui.label(
-                            egui::RichText::new("UI")
-                                .strong()
-                                .color(egui::Color32::from_rgb(180, 180, 190)),
-                        );
-                        ui.label("egui / eframe");
-                        ui.end_row();
-
-                        ui.label(
-                            egui::RichText::new("Sandbox")
-                                .strong()
-                                .color(egui::Color32::from_rgb(180, 180, 190)),
-                        );
-                        ui.label("Capability-based, 16 MB memory limit");
-                        ui.end_row();
-
-                        ui.label(
-                            egui::RichText::new("Storage")
-                                .strong()
-                                .color(egui::Color32::from_rgb(180, 180, 190)),
-                        );
-                        ui.label("sled embedded KV store");
-                        ui.end_row();
-
-                        ui.label(
-                            egui::RichText::new("License")
-                                .strong()
-                                .color(egui::Color32::from_rgb(180, 180, 190)),
-                        );
-                        ui.label("MIT");
-                        ui.end_row();
-                    });
-
-                ui.add_space(12.0);
-                ui.vertical_centered(|ui| {
-                    if ui.button("Close").clicked() {
-                        self.show_about = false;
-                    }
-                });
-                ui.add_space(4.0);
-            });
+/// Guest widget bounds in canvas-local coordinates (must match overlay hit-test skip logic).
+fn widget_bounds(cmd: &WidgetCommand) -> (f32, f32, f32, f32) {
+    match cmd {
+        WidgetCommand::Button { x, y, w, h, .. } => (*x, *y, *w, *h),
+        WidgetCommand::Checkbox { x, y, .. } => (*x, *y, 220.0, 30.0),
+        WidgetCommand::Slider { x, y, w, .. } => (*x, *y, *w, 28.0),
+        WidgetCommand::TextInput { x, y, w, .. } => (*x, *y, *w, 28.0),
     }
 }
 
-impl OxideApp {
-    fn render_tab_bar(&mut self, ctx: &egui::Context) {
-        let mut switch_to = None;
-        let mut close_idx = None;
-        let mut open_new = false;
-        let num_tabs = self.tabs.len();
-
-        egui::TopBottomPanel::top("tab_bar")
-            .exact_height(30.0)
-            .show(ctx, |ui| {
-                ui.horizontal_centered(|ui| {
-                    ui.spacing_mut().item_spacing.x = 2.0;
-
-                    for i in 0..num_tabs {
-                        let is_active = i == self.active_tab;
-                        let title = self.tabs[i].display_title();
-
-                        let bg = if is_active {
-                            egui::Color32::from_rgb(55, 55, 65)
-                        } else {
-                            egui::Color32::TRANSPARENT
-                        };
-
-                        egui::Frame::NONE
-                            .fill(bg)
-                            .inner_margin(4.0)
-                            .corner_radius(4.0)
-                            .show(ui, |ui| {
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 4.0;
-
-                                    let text_color = if is_active {
-                                        egui::Color32::from_rgb(220, 220, 230)
-                                    } else {
-                                        egui::Color32::from_rgb(150, 150, 160)
-                                    };
-
-                                    let max_len = 22;
-                                    let display = if title.chars().count() > max_len {
-                                        let truncated: String =
-                                            title.chars().take(max_len).collect();
-                                        format!("{truncated}\u{2026}")
-                                    } else {
-                                        title
-                                    };
-
-                                    let tab_label = ui.add(
-                                        egui::Label::new(
-                                            egui::RichText::new(&display)
-                                                .color(text_color)
-                                                .size(12.0),
-                                        )
-                                        .sense(egui::Sense::click()),
-                                    );
-                                    if tab_label.clicked() {
-                                        switch_to = Some(i);
-                                    }
-
-                                    if num_tabs > 1 {
-                                        let close_color = if is_active {
-                                            egui::Color32::from_rgb(160, 160, 170)
-                                        } else {
-                                            egui::Color32::from_rgb(100, 100, 110)
-                                        };
-                                        let close_btn = ui.add(
-                                            egui::Label::new(
-                                                egui::RichText::new("\u{00D7}")
-                                                    .color(close_color)
-                                                    .size(16.0),
-                                            )
-                                            .sense(egui::Sense::click()),
-                                        );
-                                        if close_btn.clicked() {
-                                            close_idx = Some(i);
-                                        }
-                                    }
-                                });
-                            });
-                    }
-
-                    ui.add_space(4.0);
-
-                    let shortcut_hint = if cfg!(target_os = "macos") {
-                        "New tab (\u{2318}T)"
-                    } else {
-                        "New tab (Ctrl+T)"
-                    };
-                    if ui
-                        .add(
-                            egui::Button::new(egui::RichText::new("+").size(16.0))
-                                .frame(false)
-                                .min_size(egui::vec2(24.0, 22.0)),
-                        )
-                        .on_hover_text(shortcut_hint)
-                        .clicked()
-                    {
-                        open_new = true;
-                    }
-                });
-            });
-
-        if let Some(i) = close_idx {
-            self.close_tab(i);
-        }
-        if open_new {
-            let idx = self.create_tab();
-            self.active_tab = idx;
-        }
-        if let Some(i) = switch_to {
-            if i < self.tabs.len() {
-                self.active_tab = i;
-            }
+/// True if `(lx, ly)` lies inside any guest widget rect (canvas space).
+fn canvas_point_hits_widget(lx: f32, ly: f32, cmds: &[WidgetCommand]) -> bool {
+    for cmd in cmds {
+        let (x, y, w, h) = widget_bounds(cmd);
+        if lx >= x && ly >= y && lx <= x + w && ly <= y + h {
+            return true;
         }
     }
+    false
 }
 
-impl OxideApp {
-    fn render_bookmarks_panel(
-        ctx: &egui::Context,
-        bookmark_store: &Option<BookmarkStore>,
-    ) -> Option<String> {
-        let store = bookmark_store.as_ref()?;
-
-        let all = store.list_all();
-        let favorites: Vec<_> = all.iter().filter(|b| b.is_favorite).collect();
-        let regular: Vec<_> = all.iter().filter(|b| !b.is_favorite).collect();
-
-        let mut navigate_url: Option<String> = None;
-        let mut toggle_fav_url: Option<String> = None;
-        let mut remove_url: Option<String> = None;
-
-        egui::SidePanel::left("bookmarks_panel")
-            .default_width(260.0)
-            .resizable(true)
-            .show(ctx, |ui| {
-                ui.heading(
-                    egui::RichText::new("\u{2605} Bookmarks")
-                        .size(16.0)
-                        .color(egui::Color32::from_rgb(255, 200, 50)),
-                );
-                ui.separator();
-
-                if all.is_empty() {
-                    ui.add_space(20.0);
-                    ui.label(
-                        egui::RichText::new("No bookmarks yet.\nClick the \u{2606} star in the toolbar to bookmark a page.")
-                            .color(egui::Color32::from_rgb(130, 130, 140))
-                            .size(12.0),
-                    );
-                    return;
-                }
-
-                egui::ScrollArea::vertical()
-                    .auto_shrink([false; 2])
-                    .show(ui, |ui| {
-                        if !favorites.is_empty() {
-                            ui.label(
-                                egui::RichText::new("Favorites")
-                                    .strong()
-                                    .size(13.0)
-                                    .color(egui::Color32::from_rgb(255, 200, 50)),
-                            );
-                            ui.add_space(4.0);
-                            for bm in &favorites {
-                                render_bookmark_row(
-                                    ui,
-                                    bm,
-                                    &mut navigate_url,
-                                    &mut toggle_fav_url,
-                                    &mut remove_url,
-                                );
-                            }
-                            if !regular.is_empty() {
-                                ui.add_space(8.0);
-                                ui.separator();
-                                ui.add_space(4.0);
-                            }
-                        }
-
-                        if !regular.is_empty() {
-                            ui.label(
-                                egui::RichText::new("All Bookmarks")
-                                    .strong()
-                                    .size(13.0)
-                                    .color(egui::Color32::from_rgb(180, 180, 190)),
-                            );
-                            ui.add_space(4.0);
-                            for bm in &regular {
-                                render_bookmark_row(
-                                    ui,
-                                    bm,
-                                    &mut navigate_url,
-                                    &mut toggle_fav_url,
-                                    &mut remove_url,
-                                );
-                            }
-                        }
-                    });
-            });
-
-        if let Some(url) = toggle_fav_url {
-            let _ = store.toggle_favorite(&url);
-        }
-        if let Some(url) = remove_url {
-            let _ = store.remove(&url);
-        }
-
-        navigate_url
-    }
-}
-
-fn render_bookmark_row(
-    ui: &mut egui::Ui,
-    bm: &crate::bookmarks::Bookmark,
-    navigate_url: &mut Option<String>,
-    toggle_fav_url: &mut Option<String>,
-    remove_url: &mut Option<String>,
-) {
-    let max_title_len = 28;
-    let display_title = if bm.title.is_empty() {
-        url_to_title(&bm.url)
-    } else {
-        bm.title.clone()
-    };
-    let truncated = if display_title.chars().count() > max_title_len {
-        let t: String = display_title.chars().take(max_title_len).collect();
+fn truncate_tab_title(title: &str) -> String {
+    let max_len = 30;
+    if title.chars().count() > max_len {
+        let t: String = title.chars().take(max_len).collect();
         format!("{t}\u{2026}")
     } else {
-        display_title
-    };
-
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 4.0;
-
-        let fav_icon = if bm.is_favorite {
-            "\u{2605}"
-        } else {
-            "\u{2606}"
-        };
-        let fav_color = if bm.is_favorite {
-            egui::Color32::from_rgb(255, 200, 50)
-        } else {
-            egui::Color32::from_rgb(120, 120, 130)
-        };
-        let fav_btn = ui.add(
-            egui::Label::new(egui::RichText::new(fav_icon).color(fav_color).size(14.0))
-                .sense(egui::Sense::click()),
-        );
-        if fav_btn.clicked() {
-            *toggle_fav_url = Some(bm.url.clone());
-        }
-        fav_btn.on_hover_text(if bm.is_favorite {
-            "Unfavorite"
-        } else {
-            "Mark as favorite"
-        });
-
-        let link = ui.add(
-            egui::Label::new(
-                egui::RichText::new(&truncated)
-                    .color(egui::Color32::from_rgb(170, 190, 255))
-                    .size(12.5),
-            )
-            .sense(egui::Sense::click()),
-        );
-        if link.clicked() {
-            *navigate_url = Some(bm.url.clone());
-        }
-        link.on_hover_text(&bm.url);
-
-        let del_btn = ui.add(
-            egui::Label::new(
-                egui::RichText::new("\u{00D7}")
-                    .color(egui::Color32::from_rgb(140, 100, 100))
-                    .size(14.0),
-            )
-            .sense(egui::Sense::click()),
-        );
-        if del_btn.clicked() {
-            *remove_url = Some(bm.url.clone());
-        }
-        del_btn.on_hover_text("Remove bookmark");
-    });
+        title.to_string()
+    }
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
+/// Typed character for URL bar and guest [`WidgetCommand::TextInput`] fields.
+/// Uses `key_char` when set; otherwise mirrors [`Keystroke::with_simulated_ime`] for plain typing.
+fn text_insert_from_keystroke(ks: &Keystroke) -> Option<String> {
+    if ks.modifiers.control || ks.modifiers.platform || ks.modifiers.function || ks.modifiers.alt {
+        return None;
+    }
+    if let Some(ref c) = ks.key_char {
+        return Some(c.clone());
+    }
+    ks.clone().with_simulated_ime().key_char
+}
+
+fn keystroke_to_oxide(k: &Keystroke) -> Option<u32> {
+    let key = k.key.as_str();
+    match key {
+        "a" => Some(0),
+        "b" => Some(1),
+        "c" => Some(2),
+        "d" => Some(3),
+        "e" => Some(4),
+        "f" => Some(5),
+        "g" => Some(6),
+        "h" => Some(7),
+        "i" => Some(8),
+        "j" => Some(9),
+        "k" => Some(10),
+        "l" => Some(11),
+        "m" => Some(12),
+        "n" => Some(13),
+        "o" => Some(14),
+        "p" => Some(15),
+        "q" => Some(16),
+        "r" => Some(17),
+        "s" => Some(18),
+        "t" => Some(19),
+        "u" => Some(20),
+        "v" => Some(21),
+        "w" => Some(22),
+        "x" => Some(23),
+        "y" => Some(24),
+        "z" => Some(25),
+        "0" => Some(26),
+        "1" => Some(27),
+        "2" => Some(28),
+        "3" => Some(29),
+        "4" => Some(30),
+        "5" => Some(31),
+        "6" => Some(32),
+        "7" => Some(33),
+        "8" => Some(34),
+        "9" => Some(35),
+        "enter" => Some(36),
+        "escape" => Some(37),
+        "tab" => Some(38),
+        "backspace" => Some(39),
+        "delete" => Some(40),
+        "space" => Some(41),
+        "up" => Some(42),
+        "down" => Some(43),
+        "left" => Some(44),
+        "right" => Some(45),
+        "home" => Some(46),
+        "end" => Some(47),
+        "pageup" => Some(48),
+        "pagedown" => Some(49),
+        _ => None,
+    }
+}
 
 fn url_to_title(url: &str) -> String {
     if url == "(local)" {
@@ -1471,59 +1640,35 @@ fn url_to_title(url: &str) -> String {
     }
 }
 
-fn egui_key_to_oxide(key: &egui::Key) -> Option<u32> {
-    use egui::Key::*;
-    match key {
-        A => Some(0),
-        B => Some(1),
-        C => Some(2),
-        D => Some(3),
-        E => Some(4),
-        F => Some(5),
-        G => Some(6),
-        H => Some(7),
-        I => Some(8),
-        J => Some(9),
-        K => Some(10),
-        L => Some(11),
-        M => Some(12),
-        N => Some(13),
-        O => Some(14),
-        P => Some(15),
-        Q => Some(16),
-        R => Some(17),
-        S => Some(18),
-        T => Some(19),
-        U => Some(20),
-        V => Some(21),
-        W => Some(22),
-        X => Some(23),
-        Y => Some(24),
-        Z => Some(25),
-        Num0 => Some(26),
-        Num1 => Some(27),
-        Num2 => Some(28),
-        Num3 => Some(29),
-        Num4 => Some(30),
-        Num5 => Some(31),
-        Num6 => Some(32),
-        Num7 => Some(33),
-        Num8 => Some(34),
-        Num9 => Some(35),
-        Enter => Some(36),
-        Escape => Some(37),
-        Tab => Some(38),
-        Backspace => Some(39),
-        Delete => Some(40),
-        Space => Some(41),
-        ArrowUp => Some(42),
-        ArrowDown => Some(43),
-        ArrowLeft => Some(44),
-        ArrowRight => Some(45),
-        Home => Some(46),
-        End => Some(47),
-        PageUp => Some(48),
-        PageDown => Some(49),
-        _ => None,
-    }
+/// Start the Oxide desktop shell: GPUI event loop and one main window.
+///
+/// Call this after constructing a [`crate::runtime::BrowserHost`] and cloning its [`HostState`]
+/// and status mutex,
+/// as the `oxide` binary does.
+/// This function does not return until the application exits.
+pub fn run_browser(host_state: HostState, status: Arc<Mutex<PageStatus>>) -> anyhow::Result<()> {
+    Application::new().run(move |cx: &mut gpui::App| {
+        cx.on_window_closed(|cx| {
+            if cx.windows().is_empty() {
+                cx.quit();
+            }
+        })
+        .detach();
+
+        let opts = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(1024.0), px(720.0)), cx)),
+            titlebar: Some(TitlebarOptions {
+                title: Some("Oxide Browser".into()),
+                ..Default::default()
+            }),
+            window_min_size: Some(size(px(600.0), px(400.0))),
+            kind: WindowKind::Normal,
+            ..Default::default()
+        };
+        cx.open_window(opts, move |_, cx| {
+            cx.new(|cx| OxideBrowserView::new(cx, host_state.clone(), status.clone()))
+        })
+        .expect("open window");
+    });
+    Ok(())
 }

--- a/oxide-browser/src/video_format.rs
+++ b/oxide-browser/src/video_format.rs
@@ -41,7 +41,7 @@ pub fn sniff_video_format(data: &[u8]) -> u32 {
     VIDEO_FORMAT_UNKNOWN
 }
 
-/// Map `Content-Type` to [`VIDEO_FORMAT_*`].
+/// Map `Content-Type` to a `VIDEO_FORMAT_*` constant (for example [`VIDEO_FORMAT_MP4`]).
 pub fn mime_to_video_format(mime: &str) -> u32 {
     let s = mime
         .split(';')

--- a/oxide-docs/index.html
+++ b/oxide-docs/index.html
@@ -136,7 +136,7 @@
             <h2>oxide-browser</h2>
             <p>
                 Host runtime internals: Wasmtime engine, sandbox policy,
-                capability provider, egui desktop UI, navigation, bookmarks,
+                capability provider, GPUI desktop shell, navigation, bookmarks,
                 and URL parsing. For browser contributors.
             </p>
         </a>

--- a/oxide-docs/src/lib.rs
+++ b/oxide-docs/src/lib.rs
@@ -8,12 +8,17 @@
 //! variables, or raw network sockets. The browser exposes a rich set of
 //! **capability APIs** that guest modules import to interact with the host.
 //!
+//! The desktop shell is built on [GPUI](https://www.gpui.rs/) (Zed's
+//! GPU-accelerated UI framework). Guest draw commands map directly onto GPUI
+//! primitives — filled quads, GPU-shaped text, vector paths, and image
+//! textures — giving your canvas output full hardware acceleration.
+//!
 //! ## Crate Map
 //!
 //! | Crate | Purpose | Audience |
 //! |-------|---------|----------|
 //! | [`oxide_sdk`] | Guest SDK — safe Rust wrappers for the `"oxide"` host imports | App developers |
-//! | [`oxide_browser`] | Host runtime — Wasmtime engine, sandbox, egui UI | Browser contributors |
+//! | [`oxide_browser`] | Host runtime — Wasmtime engine, sandbox, GPUI shell | Browser contributors |
 //!
 //! ---
 //!
@@ -30,11 +35,12 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies]
-//! oxide-sdk = "0.2"
+//! oxide-sdk = "0.4"
 //! ```
 //!
+//! ### Static app (one-shot render)
+//!
 //! ```rust,ignore
-//! // src/lib.rs
 //! use oxide_sdk::*;
 //!
 //! #[no_mangle]
@@ -42,6 +48,40 @@
 //!     log("Hello from Oxide!");
 //!     canvas_clear(30, 30, 46, 255);
 //!     canvas_text(20.0, 40.0, 28.0, 255, 255, 255, "Welcome to Oxide");
+//! }
+//! ```
+//!
+//! ### Interactive app (frame loop with widgets)
+//!
+//! ```rust,ignore
+//! use oxide_sdk::*;
+//!
+//! #[no_mangle]
+//! pub extern "C" fn start_app() { log("Ready"); }
+//!
+//! #[no_mangle]
+//! pub extern "C" fn on_frame(_dt_ms: u32) {
+//!     canvas_clear(30, 30, 46, 255);
+//!     let (mx, my) = mouse_position();
+//!     canvas_circle(mx, my, 20.0, 255, 100, 100, 255);
+//!     if ui_button(1, 20.0, 20.0, 100.0, 30.0, "Click me!") {
+//!         log("Clicked!");
+//!     }
+//! }
+//! ```
+//!
+//! ### High-level drawing API
+//!
+//! ```rust,ignore
+//! use oxide_sdk::draw::*;
+//!
+//! #[no_mangle]
+//! pub extern "C" fn start_app() {
+//!     let c = Canvas::new();
+//!     c.clear(Color::hex(0x1e1e2e));
+//!     c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
+//!     c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::RED);
+//!     c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
 //! }
 //! ```
 //!
@@ -74,8 +114,9 @@
 //! │  │          Capability Provider                  │  │
 //! │  │  "oxide" wasm import module                   │  │
 //! │  │  canvas · console · storage · clipboard       │  │
-//! │  │  fetch · audio · timers · crypto · navigation │  │
-//! │  │  widgets · input · hyperlinks · protobuf      │  │
+//! │  │  fetch · audio · video · media capture        │  │
+//! │  │  timers · crypto · navigation · widgets       │  │
+//! │  │  input · hyperlinks · protobuf                │  │
 //! │  └────────────────────┬──────────────────────────┘  │
 //! │                       │                             │
 //! │  ┌────────────────────▼──────────────────────────┐  │
@@ -93,10 +134,34 @@
 //! The [`oxide_sdk`] crate provides the full guest-side API. All functions
 //! are available via `use oxide_sdk::*;`.
 //!
-//! ## Canvas Drawing
+//! ## High-Level Drawing API (`oxide_sdk::draw`)
+//!
+//! The [`oxide_sdk::draw`] module provides GPUI-inspired ergonomic types
+//! that wrap the low-level canvas functions with less boilerplate:
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`oxide_sdk::draw::Color`] | sRGB + alpha with named constants and `hex()` constructor |
+//! | [`oxide_sdk::draw::Point2D`] | 2D point in canvas coordinates |
+//! | [`oxide_sdk::draw::Rect`] | Axis-aligned rectangle with hit-testing |
+//! | [`oxide_sdk::draw::Canvas`] | Zero-cost drawing facade |
+//!
+//! ```rust,ignore
+//! use oxide_sdk::draw::*;
+//!
+//! let c = Canvas::new();
+//! c.clear(Color::hex(0x1e1e2e));
+//! c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
+//! c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::RED);
+//! c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
+//! c.line(Point2D::ZERO, Point2D::new(400.0, 300.0), 2.0, Color::YELLOW);
+//! let (w, h) = c.dimensions();
+//! ```
+//!
+//! ## Low-Level Canvas Drawing
 //!
 //! The canvas is the main rendering surface. Coordinates start at `(0, 0)`
-//! in the top-left corner.
+//! in the top-left corner. Each draw command maps to a GPUI GPU primitive.
 //!
 //! | Function | Description |
 //! |----------|-------------|
@@ -191,12 +256,42 @@
 //! |----------|-------------|
 //! | [`oxide_sdk::audio_play`] | Play audio from encoded bytes (WAV, MP3, OGG, FLAC) |
 //! | [`oxide_sdk::audio_play_url`] | Fetch audio from a URL and play it |
+//! | [`oxide_sdk::audio_play_with_format`] | Play with a format hint |
+//! | [`oxide_sdk::audio_detect_format`] | Sniff container from magic bytes |
 //! | [`oxide_sdk::audio_pause`] / [`oxide_sdk::audio_resume`] / [`oxide_sdk::audio_stop`] | Playback control |
 //! | [`oxide_sdk::audio_set_volume`] / [`oxide_sdk::audio_get_volume`] | Volume control (0.0 – 2.0) |
 //! | [`oxide_sdk::audio_is_playing`] | Check playback state |
 //! | [`oxide_sdk::audio_position`] / [`oxide_sdk::audio_seek`] / [`oxide_sdk::audio_duration`] | Seek and position |
 //! | [`oxide_sdk::audio_set_loop`] | Enable/disable looping |
 //! | [`oxide_sdk::audio_channel_play`] | Multi-channel simultaneous playback |
+//!
+//! ## Video
+//!
+//! Video decoding uses FFmpeg on the host. Frames are rendered as GPUI
+//! textures for GPU-accelerated compositing.
+//!
+//! | Function | Description |
+//! |----------|-------------|
+//! | [`oxide_sdk::video_load`] / [`oxide_sdk::video_load_url`] | Load video from bytes or URL |
+//! | [`oxide_sdk::video_play`] / [`oxide_sdk::video_pause`] / [`oxide_sdk::video_stop`] | Playback control |
+//! | [`oxide_sdk::video_render`] | Draw current frame to canvas rectangle |
+//! | [`oxide_sdk::video_seek`] / [`oxide_sdk::video_position`] / [`oxide_sdk::video_duration`] | Seek and timing |
+//! | [`oxide_sdk::video_set_volume`] / [`oxide_sdk::video_set_loop`] | Volume and looping |
+//! | [`oxide_sdk::video_set_pip`] | Picture-in-picture floating preview |
+//! | [`oxide_sdk::video_hls_variant_count`] / [`oxide_sdk::video_hls_open_variant`] | HLS adaptive streaming |
+//! | [`oxide_sdk::subtitle_load_srt`] / [`oxide_sdk::subtitle_load_vtt`] | Load subtitles |
+//!
+//! ## Media Capture
+//!
+//! The host shows permission dialogs before granting access to hardware.
+//!
+//! | Function | Description |
+//! |----------|-------------|
+//! | [`oxide_sdk::camera_open`] / [`oxide_sdk::camera_close`] | Camera stream |
+//! | [`oxide_sdk::camera_capture_frame`] / [`oxide_sdk::camera_frame_dimensions`] | Capture RGBA8 frames |
+//! | [`oxide_sdk::microphone_open`] / [`oxide_sdk::microphone_close`] | Microphone stream |
+//! | [`oxide_sdk::microphone_read_samples`] / [`oxide_sdk::microphone_sample_rate`] | Read mono f32 samples |
+//! | [`oxide_sdk::screen_capture`] / [`oxide_sdk::screen_capture_dimensions`] | Screenshot |
 //!
 //! ## Timers
 //!
@@ -283,8 +378,8 @@
 //!   persistent bookmark storage backed by sled.
 //! - **[`oxide_browser::url`]** — [`oxide_browser::url::OxideUrl`] wraps WHATWG URL parsing with
 //!   support for `http`, `https`, `file`, and `oxide://` schemes.
-//! - **[`oxide_browser::ui`]** — [`oxide_browser::ui::OxideApp`] is the egui/eframe application
-//!   with tabbed browsing, toolbar, canvas rendering, console panel, and bookmarks sidebar.
+//! - **[`oxide_browser::ui`]** — [`oxide_browser::ui::OxideBrowserView`] and [`oxide_browser::ui::run_browser`]
+//!   implement tabbed browsing, toolbar, canvas rendering, console panel, and bookmarks sidebar.
 //!
 //! ---
 //!

--- a/oxide-docs/src/lib.rs
+++ b/oxide-docs/src/lib.rs
@@ -47,7 +47,7 @@
 //! pub extern "C" fn start_app() {
 //!     log("Hello from Oxide!");
 //!     canvas_clear(30, 30, 46, 255);
-//!     canvas_text(20.0, 40.0, 28.0, 255, 255, 255, "Welcome to Oxide");
+//!     canvas_text(20.0, 40.0, 28.0, 255, 255, 255, 255, "Welcome to Oxide");
 //! }
 //! ```
 //!
@@ -179,8 +179,8 @@
 //! canvas_clear(30, 30, 46, 255);
 //! canvas_rect(10.0, 10.0, 200.0, 100.0, 80, 120, 200, 255);
 //! canvas_circle(300.0, 200.0, 50.0, 200, 100, 150, 255);
-//! canvas_text(20.0, 30.0, 24.0, 255, 255, 255, "Hello!");
-//! canvas_line(0.0, 0.0, 400.0, 300.0, 255, 200, 0, 2.0);
+//! canvas_text(20.0, 30.0, 24.0, 255, 255, 255, 255, "Hello!");
+//! canvas_line(0.0, 0.0, 400.0, 300.0, 255, 200, 0, 255, 2.0);
 //!
 //! let (w, h) = canvas_dimensions();
 //! log(&format!("Canvas: {}x{}", w, h));

--- a/oxide-landing/index.html
+++ b/oxide-landing/index.html
@@ -228,8 +228,8 @@
                     <div class="tech-desc">Async runtime for network operations</div>
                 </div>
                 <div class="tech-card">
-                    <div class="tech-name">egui</div>
-                    <div class="tech-desc">Immediate-mode GUI for URL bar, canvas & console</div>
+                    <div class="tech-name">GPUI</div>
+                    <div class="tech-desc">GPU-accelerated UI for the shell (Zed-style)</div>
                 </div>
                 <div class="tech-card">
                     <div class="tech-name">protobuf</div>

--- a/oxide-sdk/README.md
+++ b/oxide-sdk/README.md
@@ -33,7 +33,7 @@ use oxide_sdk::*;
 pub extern "C" fn start_app() {
     log("Hello from Oxide!");
     canvas_clear(30, 30, 46, 255);
-    canvas_text(20.0, 40.0, 28.0, 255, 255, 255, "Welcome to Oxide");
+    canvas_text(20.0, 40.0, 28.0, 255, 255, 255, 255, "Welcome to Oxide");
 }
 ```
 

--- a/oxide-sdk/src/draw.rs
+++ b/oxide-sdk/src/draw.rs
@@ -1,0 +1,193 @@
+//! Higher-level drawing API inspired by GPUI's rendering model.
+//!
+//! This module provides ergonomic types and a builder-style [`Canvas`] facade
+//! that wraps the low-level `canvas_*` functions. Guest apps can choose between
+//! the raw functions (maximum control) and these helpers (less boilerplate).
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use oxide_sdk::draw::*;
+//!
+//! let mut c = Canvas::new();
+//! c.clear(Color::rgb(30, 30, 46));
+//! c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
+//! c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::rgba(200, 100, 150, 200));
+//! c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
+//! c.line(Point2D::new(0.0, 0.0), Point2D::new(400.0, 300.0), 2.0, Color::YELLOW);
+//! ```
+
+/// sRGB color with alpha.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl Color {
+    /// Opaque color from RGB channels.
+    pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: 255 }
+    }
+
+    /// Color with explicit alpha.
+    pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self { r, g, b, a }
+    }
+
+    /// Parse a 24-bit hex value (e.g. `0xFF8040`) into an opaque color.
+    pub const fn hex(hex: u32) -> Self {
+        Self {
+            r: ((hex >> 16) & 0xFF) as u8,
+            g: ((hex >> 8) & 0xFF) as u8,
+            b: (hex & 0xFF) as u8,
+            a: 255,
+        }
+    }
+
+    /// Return this color with a different alpha value.
+    pub const fn with_alpha(self, a: u8) -> Self {
+        Self { a, ..self }
+    }
+
+    pub const WHITE: Self = Self::rgb(255, 255, 255);
+    pub const BLACK: Self = Self::rgb(0, 0, 0);
+    pub const RED: Self = Self::rgb(255, 0, 0);
+    pub const GREEN: Self = Self::rgb(0, 255, 0);
+    pub const BLUE: Self = Self::rgb(0, 0, 255);
+    pub const YELLOW: Self = Self::rgb(255, 255, 0);
+    pub const CYAN: Self = Self::rgb(0, 255, 255);
+    pub const MAGENTA: Self = Self::rgb(255, 0, 255);
+    pub const TRANSPARENT: Self = Self::rgba(0, 0, 0, 0);
+}
+
+impl Default for Color {
+    fn default() -> Self {
+        Self::WHITE
+    }
+}
+
+/// A 2D point in canvas coordinates.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Point2D {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Point2D {
+    pub const fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    pub const ZERO: Self = Self::new(0.0, 0.0);
+}
+
+/// An axis-aligned rectangle in canvas coordinates.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Rect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+impl Rect {
+    pub const fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
+        Self { x, y, w, h }
+    }
+
+    /// Create from origin point and size.
+    pub const fn from_point_size(origin: Point2D, w: f32, h: f32) -> Self {
+        Self {
+            x: origin.x,
+            y: origin.y,
+            w,
+            h,
+        }
+    }
+
+    /// True if the point `(px, py)` is inside this rectangle.
+    pub fn contains(&self, px: f32, py: f32) -> bool {
+        px >= self.x && py >= self.y && px <= self.x + self.w && py <= self.y + self.h
+    }
+
+    pub fn origin(&self) -> Point2D {
+        Point2D::new(self.x, self.y)
+    }
+
+    pub fn center(&self) -> Point2D {
+        Point2D::new(self.x + self.w / 2.0, self.y + self.h / 2.0)
+    }
+}
+
+/// Builder-style canvas facade that wraps the low-level drawing functions.
+///
+/// All methods paint immediately (no retained scene graph). Create one per
+/// frame or per `start_app` call and issue draw commands through it.
+pub struct Canvas;
+
+impl Canvas {
+    /// Create a new canvas handle. This is zero-cost — no allocation occurs.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Clear the canvas with a solid color.
+    pub fn clear(&self, color: Color) {
+        crate::canvas_clear(color.r, color.g, color.b, color.a);
+    }
+
+    /// Draw a filled rectangle.
+    pub fn fill_rect(&self, rect: Rect, color: Color) {
+        crate::canvas_rect(
+            rect.x, rect.y, rect.w, rect.h, color.r, color.g, color.b, color.a,
+        );
+    }
+
+    /// Draw a filled circle.
+    pub fn fill_circle(&self, center: Point2D, radius: f32, color: Color) {
+        crate::canvas_circle(
+            center.x, center.y, radius, color.r, color.g, color.b, color.a,
+        );
+    }
+
+    /// Draw text at a position.
+    pub fn text(&self, text: &str, pos: Point2D, size: f32, color: Color) {
+        crate::canvas_text(pos.x, pos.y, size, color.r, color.g, color.b, text);
+    }
+
+    /// Draw a line between two points.
+    pub fn line(&self, from: Point2D, to: Point2D, thickness: f32, color: Color) {
+        crate::canvas_line(
+            from.x, from.y, to.x, to.y, color.r, color.g, color.b, thickness,
+        );
+    }
+
+    /// Draw an image from encoded bytes (PNG, JPEG, GIF, WebP).
+    pub fn image(&self, rect: Rect, data: &[u8]) {
+        crate::canvas_image(rect.x, rect.y, rect.w, rect.h, data);
+    }
+
+    /// Get the canvas dimensions in pixels.
+    pub fn dimensions(&self) -> (u32, u32) {
+        crate::canvas_dimensions()
+    }
+
+    /// Get the canvas width in pixels.
+    pub fn width(&self) -> u32 {
+        self.dimensions().0
+    }
+
+    /// Get the canvas height in pixels.
+    pub fn height(&self) -> u32 {
+        self.dimensions().1
+    }
+}
+
+impl Default for Canvas {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/oxide-sdk/src/draw.rs
+++ b/oxide-sdk/src/draw.rs
@@ -1,6 +1,6 @@
 //! Higher-level drawing API inspired by GPUI's rendering model.
 //!
-//! This module provides ergonomic types and a builder-style [`Canvas`] facade
+//! This module provides ergonomic types and an immediate-mode [`Canvas`] facade
 //! that wraps the low-level `canvas_*` functions. Guest apps can choose between
 //! the raw functions (maximum control) and these helpers (less boilerplate).
 //!
@@ -9,7 +9,7 @@
 //! ```rust,ignore
 //! use oxide_sdk::draw::*;
 //!
-//! let mut c = Canvas::new();
+//! let c = Canvas::new();
 //! c.clear(Color::rgb(30, 30, 46));
 //! c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
 //! c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::rgba(200, 100, 150, 200));
@@ -48,6 +48,7 @@ impl Color {
     }
 
     /// Return this color with a different alpha value.
+    #[must_use]
     pub const fn with_alpha(self, a: u8) -> Self {
         Self { a, ..self }
     }
@@ -108,9 +109,10 @@ impl Rect {
         }
     }
 
-    /// True if the point `(px, py)` is inside this rectangle.
+    /// True if the point `(px, py)` is inside this rectangle (half-open: inclusive on
+    /// the near edge, exclusive on the far edge).
     pub fn contains(&self, px: f32, py: f32) -> bool {
-        px >= self.x && py >= self.y && px <= self.x + self.w && py <= self.y + self.h
+        px >= self.x && py >= self.y && px < self.x + self.w && py < self.y + self.h
     }
 
     pub fn origin(&self) -> Point2D {
@@ -122,7 +124,7 @@ impl Rect {
     }
 }
 
-/// Builder-style canvas facade that wraps the low-level drawing functions.
+/// Immediate-mode canvas facade that wraps the low-level drawing functions.
 ///
 /// All methods paint immediately (no retained scene graph). Create one per
 /// frame or per `start_app` call and issue draw commands through it.
@@ -155,13 +157,13 @@ impl Canvas {
 
     /// Draw text at a position.
     pub fn text(&self, text: &str, pos: Point2D, size: f32, color: Color) {
-        crate::canvas_text(pos.x, pos.y, size, color.r, color.g, color.b, text);
+        crate::canvas_text(pos.x, pos.y, size, color.r, color.g, color.b, color.a, text);
     }
 
     /// Draw a line between two points.
     pub fn line(&self, from: Point2D, to: Point2D, thickness: f32, color: Color) {
         crate::canvas_line(
-            from.x, from.y, to.x, to.y, color.r, color.g, color.b, thickness,
+            from.x, from.y, to.x, to.y, color.r, color.g, color.b, color.a, thickness,
         );
     }
 

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -30,7 +30,7 @@
 //! pub extern "C" fn start_app() {
 //!     log("Hello from Oxide!");
 //!     canvas_clear(30, 30, 46, 255);
-//!     canvas_text(20.0, 40.0, 28.0, 255, 255, 255, "Welcome to Oxide");
+//!     canvas_text(20.0, 40.0, 28.0, 255, 255, 255, 255, "Welcome to Oxide");
 //! }
 //! ```
 //!
@@ -145,10 +145,10 @@ extern "C" {
     fn _api_canvas_circle(cx: f32, cy: f32, radius: f32, r: u32, g: u32, b: u32, a: u32);
 
     #[link_name = "api_canvas_text"]
-    fn _api_canvas_text(x: f32, y: f32, size: f32, r: u32, g: u32, b: u32, ptr: u32, len: u32);
+    fn _api_canvas_text(x: f32, y: f32, size: f32, r: u32, g: u32, b: u32, a: u32, ptr: u32, len: u32);
 
     #[link_name = "api_canvas_line"]
-    fn _api_canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u32, g: u32, b: u32, thickness: f32);
+    fn _api_canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u32, g: u32, b: u32, a: u32, thickness: f32);
 
     #[link_name = "api_canvas_dimensions"]
     fn _api_canvas_dimensions() -> u64;
@@ -595,8 +595,8 @@ pub fn canvas_circle(cx: f32, cy: f32, radius: f32, r: u8, g: u8, b: u8, a: u8) 
     unsafe { _api_canvas_circle(cx, cy, radius, r as u32, g as u32, b as u32, a as u32) }
 }
 
-/// Draw text on the canvas.
-pub fn canvas_text(x: f32, y: f32, size: f32, r: u8, g: u8, b: u8, text: &str) {
+/// Draw text on the canvas with RGBA color.
+pub fn canvas_text(x: f32, y: f32, size: f32, r: u8, g: u8, b: u8, a: u8, text: &str) {
     unsafe {
         _api_canvas_text(
             x,
@@ -605,15 +605,16 @@ pub fn canvas_text(x: f32, y: f32, size: f32, r: u8, g: u8, b: u8, text: &str) {
             r as u32,
             g as u32,
             b as u32,
+            a as u32,
             text.as_ptr() as u32,
             text.len() as u32,
         )
     }
 }
 
-/// Draw a line between two points.
-pub fn canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u8, g: u8, b: u8, thickness: f32) {
-    unsafe { _api_canvas_line(x1, y1, x2, y2, r as u32, g as u32, b as u32, thickness) }
+/// Draw a line between two points with RGBA color.
+pub fn canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u8, g: u8, b: u8, a: u8, thickness: f32) {
+    unsafe { _api_canvas_line(x1, y1, x2, y2, r as u32, g as u32, b as u32, a as u32, thickness) }
 }
 
 /// Returns `(width, height)` of the canvas in pixels.

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -145,10 +145,30 @@ extern "C" {
     fn _api_canvas_circle(cx: f32, cy: f32, radius: f32, r: u32, g: u32, b: u32, a: u32);
 
     #[link_name = "api_canvas_text"]
-    fn _api_canvas_text(x: f32, y: f32, size: f32, r: u32, g: u32, b: u32, a: u32, ptr: u32, len: u32);
+    fn _api_canvas_text(
+        x: f32,
+        y: f32,
+        size: f32,
+        r: u32,
+        g: u32,
+        b: u32,
+        a: u32,
+        ptr: u32,
+        len: u32,
+    );
 
     #[link_name = "api_canvas_line"]
-    fn _api_canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u32, g: u32, b: u32, a: u32, thickness: f32);
+    fn _api_canvas_line(
+        x1: f32,
+        y1: f32,
+        x2: f32,
+        y2: f32,
+        r: u32,
+        g: u32,
+        b: u32,
+        a: u32,
+        thickness: f32,
+    );
 
     #[link_name = "api_canvas_dimensions"]
     fn _api_canvas_dimensions() -> u64;
@@ -614,7 +634,11 @@ pub fn canvas_text(x: f32, y: f32, size: f32, r: u8, g: u8, b: u8, a: u8, text: 
 
 /// Draw a line between two points with RGBA color.
 pub fn canvas_line(x1: f32, y1: f32, x2: f32, y2: f32, r: u8, g: u8, b: u8, a: u8, thickness: f32) {
-    unsafe { _api_canvas_line(x1, y1, x2, y2, r as u32, g as u32, b as u32, a as u32, thickness) }
+    unsafe {
+        _api_canvas_line(
+            x1, y1, x2, y2, r as u32, g as u32, b as u32, a as u32, thickness,
+        )
+    }
 }
 
 /// Returns `(width, height)` of the canvas in pixels.

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -5,19 +5,23 @@
 //! safe Rust wrappers around the raw host-imported functions exposed by the
 //! `"oxide"` wasm import module.
 //!
-//! ## Quick Start
+//! The desktop shell uses [GPUI](https://www.gpui.rs/) (Zed's GPU-accelerated
+//! UI framework) to render guest draw commands. The SDK exposes a drawing API
+//! that maps directly onto GPUI primitives — filled quads, GPU-shaped text,
+//! vector paths, and image textures — so your canvas output gets full GPU
+//! acceleration without you having to link GPUI itself.
 //!
-//! Add `oxide-sdk` to your `Cargo.toml` and set `crate-type = ["cdylib"]`:
+//! ## Quick Start
 //!
 //! ```toml
 //! [lib]
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies]
-//! oxide-sdk = "0.2"
+//! oxide-sdk = "0.4"
 //! ```
 //!
-//! Then write your app:
+//! ### Static app (one-shot render)
 //!
 //! ```rust,ignore
 //! use oxide_sdk::*;
@@ -30,11 +34,7 @@
 //! }
 //! ```
 //!
-//! Build with `cargo build --target wasm32-unknown-unknown --release`.
-//!
-//! ## Interactive Apps
-//!
-//! For apps that need a render loop, export `on_frame`:
+//! ### Interactive app (frame loop)
 //!
 //! ```rust,ignore
 //! use oxide_sdk::*;
@@ -56,30 +56,64 @@
 //! }
 //! ```
 //!
+//! ### High-level drawing API
+//!
+//! The [`draw`] module provides GPUI-inspired ergonomic types for less
+//! boilerplate:
+//!
+//! ```rust,ignore
+//! use oxide_sdk::draw::*;
+//!
+//! #[no_mangle]
+//! pub extern "C" fn start_app() {
+//!     let c = Canvas::new();
+//!     c.clear(Color::hex(0x1e1e2e));
+//!     c.fill_rect(Rect::new(10.0, 10.0, 200.0, 100.0), Color::rgb(80, 120, 200));
+//!     c.fill_circle(Point2D::new(300.0, 200.0), 50.0, Color::RED);
+//!     c.text("Hello!", Point2D::new(20.0, 30.0), 24.0, Color::WHITE);
+//! }
+//! ```
+//!
+//! Build with `cargo build --target wasm32-unknown-unknown --release`.
+//!
 //! ## API Categories
 //!
-//! | Category | Functions |
+//! | Category | Key types / functions |
 //! |----------|-----------|
-//! | **Canvas** | [`canvas_clear`], [`canvas_rect`], [`canvas_circle`], [`canvas_text`], [`canvas_line`], [`canvas_image`], [`canvas_dimensions`] |
+//! | **Drawing (high-level)** | [`draw::Canvas`], [`draw::Color`], [`draw::Rect`], [`draw::Point2D`] |
+//! | **Canvas (low-level)** | [`canvas_clear`], [`canvas_rect`], [`canvas_circle`], [`canvas_text`], [`canvas_line`], [`canvas_image`], [`canvas_dimensions`] |
 //! | **Console** | [`log`], [`warn`], [`error`] |
 //! | **HTTP** | [`fetch`], [`fetch_get`], [`fetch_post`], [`fetch_post_proto`], [`fetch_put`], [`fetch_delete`] |
 //! | **Protobuf** | [`proto::ProtoEncoder`], [`proto::ProtoDecoder`] |
 //! | **Storage** | [`storage_set`], [`storage_get`], [`storage_remove`], [`kv_store_set`], [`kv_store_get`], [`kv_store_delete`] |
-//! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_detect_format`], [`audio_play_with_format`], [`audio_last_url_content_type`], [`audio_pause`], [`audio_channel_play`] |
+//! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_detect_format`], [`audio_play_with_format`], [`audio_pause`], [`audio_channel_play`] |
 //! | **Video** | [`video_load`], [`video_load_url`], [`video_render`], [`video_play`], [`video_hls_open_variant`], [`subtitle_load_srt`] |
-//! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`], [`media_pipeline_stats`] |
+//! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`] |
 //! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
-//! | **Input** | [`mouse_position`], [`mouse_button_down`], [`key_down`], [`key_pressed`], [`scroll_delta`] |
+//! | **Input** | [`mouse_position`], [`mouse_button_down`], [`mouse_button_clicked`], [`key_down`], [`key_pressed`], [`scroll_delta`], [`modifiers`] |
 //! | **Widgets** | [`ui_button`], [`ui_checkbox`], [`ui_slider`], [`ui_text_input`] |
 //! | **Crypto** | [`hash_sha256`], [`hash_sha256_hex`], [`base64_encode`], [`base64_decode`] |
 //! | **Other** | [`clipboard_write`], [`clipboard_read`], [`random_u64`], [`random_f64`], [`notify`], [`upload_file`], [`load_module`] |
+//!
+//! ## Guest Module Contract
+//!
+//! Every `.wasm` module loaded by Oxide must:
+//!
+//! 1. **Export `start_app`** — `extern "C" fn()` entry point, called once on load.
+//! 2. **Optionally export `on_frame`** — `extern "C" fn(dt_ms: u32)` for
+//!    interactive apps with a render loop (called every frame, fuel replenished).
+//! 3. **Optionally export `on_timer`** — `extern "C" fn(callback_id: u32)`
+//!    to receive timer callbacks from [`set_timeout`] / [`set_interval`].
+//! 4. **Compile as `cdylib`** — `crate-type = ["cdylib"]` in `Cargo.toml`.
+//! 5. **Target `wasm32-unknown-unknown`** — no WASI, pure capability-based I/O.
 //!
 //! ## Full API Documentation
 //!
 //! See <https://docs.oxide.foundation/oxide_sdk/> for the complete API
 //! reference, or browse the individual function documentation below.
 
+pub mod draw;
 pub mod proto;
 
 // ─── Raw FFI imports from the host ──────────────────────────────────────────


### PR DESCRIPTION
…, and update docs

Three input-handling bugs introduced during the egui → GPUI migration are fixed, a new GPUI-inspired drawing module is added to the SDK, and all documentation is updated to reflect the current API surface.

## Bug fixes (ui.rs)

- **Modifier keys never synced**: `modifiers_shift`, `modifiers_ctrl`, and `modifiers_alt` in `InputState` were never populated from GPUI keystroke events. The SDK functions `shift_held()`, `ctrl_held()`, `alt_held()` always returned false. Fixed by reading `event.keystroke.modifiers` in both `on_key_down` and `on_key_up` handlers.

- **Canvas dimensions hardcoded to 800×600**: `CanvasState.width/height` were set once in `Default::default()` and never updated from the actual GPUI canvas bounds. `canvas_dimensions()` always returned (800, 600). Fixed by writing `bounds.size` into `CanvasState` in the canvas prepare callback each frame.

- **Right/middle mouse clicks not tracked**: Only the left mouse button was reflected in `mouse_buttons_clicked`. The `on_mouse_up` handlers for Right and Middle now set the corresponding clicked flag, and the duplicate left-click tracking in `on_click` is removed to avoid double-counting.

## New: oxide-sdk/src/draw.rs

Added a high-level drawing module inspired by GPUI conventions:
- `Color` — sRGB+alpha with `rgb()`, `rgba()`, `hex()`, named constants
- `Point2D` — 2D canvas point
- `Rect` — axis-aligned rectangle with `contains()` hit-testing
- `Canvas` — zero-cost facade wrapping low-level `canvas_*` functions

## Documentation

- Rewrote DOCS.md with complete API reference covering all ~100 host functions: canvas (low-level + high-level), widgets, audio, video, media capture, timers, navigation, hyperlinks, crypto, and troubleshooting.
- Updated oxide-sdk module docs with draw module, version references, and guest module contract.
- Updated oxide-browser/src/lib.rs with GPUI-to-SDK mapping table showing how each SDK draw call translates to GPUI GPU primitives.
- Updated oxide-docs/src/lib.rs with high-level drawing API, video, and media capture sections.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-driven UI backend (GPUI) powering an accelerated desktop shell and rendering model
  * High-level drawing API (Canvas, Color, Point2D, Rect) for ergonomic immediate-mode drawing
  * Guest lifecycle: optional on_frame() and on_timer() hooks for interactive apps

* **API Changes**
  * Low-level canvas text/line calls now accept an explicit alpha/opacity parameter

* **Documentation**
  * Expanded guides, examples (static vs interactive), multimedia, input, and troubleshooting content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->