### PR TITLE
feat(browser): WebSocket host API and ws-chat example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ yarn-error.log*
 
 # Environment files (local configs)
 /.env.*
+
+.cursor/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = [
     "examples/media-capture",
     "examples/gpu-graphics-demo",
     "examples/rtc-chat",
+    "examples/ws-chat",
 ]
 resolver = "2"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -257,7 +257,7 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 
 - [ ] Non-blocking fetch with callback/promise-style API
 - [ ] Streaming response bodies (chunked transfer)
-- [ ] WebSocket support: `ws_connect(url)`, `ws_send()`, `ws_on_message()`
+- [x] WebSocket support: `ws_connect(url)`, `ws_send_text()`, `ws_send_binary()`, `ws_recv()`, `ws_ready_state()`, `ws_close()`
 - [ ] Server-sent events (SSE) for push updates
 
 ---

--- a/examples/ws-chat/Cargo.toml
+++ b/examples/ws-chat/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ws-chat"
+version = "0.1.0"
+edition = "2021"
+description = "WebSocket chat demo for the Oxide browser"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/ws-chat/src/lib.rs
+++ b/examples/ws-chat/src/lib.rs
@@ -1,0 +1,325 @@
+//! WebSocket chat demo.
+//!
+//! Demonstrates the Oxide WebSocket API: connect to a server, send text
+//! frames, and poll for incoming messages — all from a guest `.wasm` module.
+//!
+//! By default the app connects to a local echo server at `ws://127.0.0.1:9001`.
+//! Enter any `ws://` or `wss://` URL in the address bar and press Connect.
+//!
+//! # Building
+//!
+//! ```bash
+//! cargo build --target wasm32-unknown-unknown --release -p ws-chat
+//! ```
+//!
+//! Then open the resulting `.wasm` in the Oxide browser.
+
+use oxide_sdk::*;
+
+const MAX_MESSAGES: usize = 30;
+const MSG_BUF_SIZE: usize = 512;
+
+static mut STATE: AppState = AppState::new();
+
+/// Persistent app state stored as a static (no heap allocation needed).
+struct AppState {
+    // ── Connection ────────────────────────────────────────────────────────
+    ws_id: u32,
+    connected: bool,
+
+    // ── URL input field ───────────────────────────────────────────────────
+    url_buf: [u8; 256],
+    url_len: usize,
+
+    // ── Message input field ───────────────────────────────────────────────
+    msg_buf: [u8; MSG_BUF_SIZE],
+    msg_len: usize,
+
+    // ── Received/sent message log ─────────────────────────────────────────
+    // Each entry: (direction: 0=recv 1=sent 2=system, text bytes, length)
+    log: [(u8, [u8; MSG_BUF_SIZE], usize); MAX_MESSAGES],
+    log_count: usize,
+
+    // ── Scroll offset for the message list ────────────────────────────────
+    scroll_offset: f32,
+}
+
+impl AppState {
+    const fn new() -> Self {
+        Self {
+            ws_id: 0,
+            connected: false,
+            url_buf: {
+                let mut b = [0u8; 256];
+                let src = b"ws://127.0.0.1:9001";
+                let mut i = 0;
+                while i < src.len() {
+                    b[i] = src[i];
+                    i += 1;
+                }
+                b
+            },
+            url_len: 19, // length of "ws://127.0.0.1:9001"
+            msg_buf: [0u8; MSG_BUF_SIZE],
+            msg_len: 0,
+            log: [(0, [0u8; MSG_BUF_SIZE], 0); MAX_MESSAGES],
+            log_count: 0,
+            scroll_offset: 0.0,
+        }
+    }
+
+    fn url(&self) -> &str {
+        core::str::from_utf8(&self.url_buf[..self.url_len]).unwrap_or("")
+    }
+
+    fn message_text(&self) -> &str {
+        core::str::from_utf8(&self.msg_buf[..self.msg_len]).unwrap_or("")
+    }
+
+    fn push_log(&mut self, direction: u8, text: &str) {
+        if self.log_count >= MAX_MESSAGES {
+            // Scroll the ring buffer.
+            for i in 0..MAX_MESSAGES - 1 {
+                self.log[i] = self.log[i + 1];
+            }
+            self.log_count = MAX_MESSAGES - 1;
+        }
+        let idx = self.log_count;
+        self.log[idx].0 = direction;
+        let bytes = text.as_bytes();
+        let len = bytes.len().min(MSG_BUF_SIZE);
+        self.log[idx].1[..len].copy_from_slice(&bytes[..len]);
+        self.log[idx].2 = len;
+        self.log_count += 1;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("WS Chat demo loaded");
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let s = unsafe { &mut *core::ptr::addr_of_mut!(STATE) };
+    let (width, height) = canvas_dimensions();
+    let w = width as f32;
+    let h = height as f32;
+
+    // ── Background ────────────────────────────────────────────────────────
+    canvas_clear(22, 27, 42, 255);
+
+    // ── Header bar ───────────────────────────────────────────────────────
+    canvas_rect(0.0, 0.0, w, 48.0, 30, 38, 68, 255);
+    canvas_text(14.0, 14.0, 20.0, 160, 200, 255, 255, "Oxide WebSocket Chat");
+
+    // Connection state badge
+    let (badge_r, badge_g, badge_b, badge_text) = match ws_ready_state(s.ws_id) {
+        WS_CONNECTING => (200, 160, 0, "CONNECTING"),
+        WS_OPEN => (40, 200, 100, "CONNECTED"),
+        WS_CLOSING => (200, 120, 0, "CLOSING"),
+        _ => {
+            if s.ws_id > 0 {
+                s.connected = false;
+                (180, 60, 60, "CLOSED")
+            } else {
+                (100, 100, 120, "DISCONNECTED")
+            }
+        }
+    };
+    canvas_rounded_rect(
+        w - 130.0,
+        12.0,
+        118.0,
+        24.0,
+        12.0,
+        badge_r,
+        badge_g,
+        badge_b,
+        50,
+    );
+    canvas_text(
+        w - 122.0,
+        17.0,
+        13.0,
+        badge_r,
+        badge_g,
+        badge_b,
+        255,
+        badge_text,
+    );
+
+    // ── URL / Connect row ─────────────────────────────────────────────────
+    let row_y = 60.0;
+    canvas_text(14.0, row_y + 4.0, 13.0, 140, 150, 180, 255, "Server:");
+    let url_val = ui_text_input(1, 70.0, row_y, w - 190.0, s.url());
+    // Persist whatever the user typed.
+    {
+        let bytes = url_val.as_bytes();
+        let len = bytes.len().min(255);
+        s.url_buf[..len].copy_from_slice(&bytes[..len]);
+        s.url_len = len;
+    }
+
+    let btn_x = w - 110.0;
+    let btn_label = if s.connected || ws_ready_state(s.ws_id) == WS_OPEN {
+        "Disconnect"
+    } else {
+        "Connect"
+    };
+
+    if ui_button(2, btn_x, row_y, 96.0, 28.0, btn_label) {
+        if s.connected || ws_ready_state(s.ws_id) == WS_OPEN {
+            ws_close(s.ws_id);
+            s.connected = false;
+            s.push_log(2, "Disconnecting…");
+        } else {
+            let url = {
+                // Copy URL into a stack buffer so we can pass a &str without
+                // holding a borrow on `s`.
+                let mut tmp = [0u8; 256];
+                let len = s.url_len;
+                tmp[..len].copy_from_slice(&s.url_buf[..len]);
+                (tmp, len)
+            };
+            let url_str = core::str::from_utf8(&url.0[..url.1]).unwrap_or("");
+            let id = ws_connect(url_str);
+            if id > 0 {
+                s.ws_id = id;
+                s.connected = true;
+                s.push_log(2, "Connecting…");
+            } else {
+                s.push_log(2, "Failed to initiate connection.");
+            }
+        }
+    }
+
+    // ── Drain incoming messages ───────────────────────────────────────────
+    if s.ws_id > 0 {
+        while let Some(msg) = ws_recv(s.ws_id) {
+            let text = if msg.is_binary {
+                format_bytes_preview(&msg.data)
+            } else {
+                msg.text()
+            };
+            s.push_log(0, &text);
+        }
+        // Detect remote close.
+        if ws_ready_state(s.ws_id) == WS_CLOSED && s.connected {
+            s.connected = false;
+            s.push_log(2, "Connection closed by server.");
+            ws_remove(s.ws_id);
+        }
+    }
+
+    // ── Message log area ─────────────────────────────────────────────────
+    let log_top = row_y + 40.0;
+    let log_bottom = h - 50.0;
+    let log_h = log_bottom - log_top;
+    canvas_rounded_rect(10.0, log_top, w - 20.0, log_h, 6.0, 14, 20, 35, 255);
+
+    // Scroll on mouse wheel.
+    let (_, dy) = scroll_delta();
+    s.scroll_offset = (s.scroll_offset + dy * 20.0).max(0.0);
+
+    let line_h = 22.0;
+    let total_h = s.log_count as f32 * line_h;
+    let max_scroll = (total_h - log_h + 8.0).max(0.0);
+    if s.scroll_offset > max_scroll {
+        s.scroll_offset = max_scroll;
+    }
+
+    let visible_lines = ((log_h / line_h) as usize).min(s.log_count);
+    let first_idx = if s.log_count > visible_lines {
+        let auto_scroll = (total_h - s.scroll_offset - log_h) < line_h;
+        if auto_scroll {
+            s.log_count - visible_lines
+        } else {
+            let scroll_idx = (s.scroll_offset / line_h) as usize;
+            scroll_idx.min(s.log_count - visible_lines)
+        }
+    } else {
+        0
+    };
+
+    for i in 0..visible_lines {
+        let idx = first_idx + i;
+        if idx >= s.log_count {
+            break;
+        }
+        let dir = s.log[idx].0;
+        let len = s.log[idx].2;
+        let text = core::str::from_utf8(&s.log[idx].1[..len]).unwrap_or("(invalid utf-8)");
+        let y = log_top + 8.0 + i as f32 * line_h;
+
+        // Colour coding: received=green, sent=blue, system=grey
+        let (prefix, pr, pg, pb) = match dir {
+            0 => ("▼ ", 80u8, 220u8, 140u8),
+            1 => ("▲ ", 100u8, 160u8, 255u8),
+            _ => ("• ", 140u8, 150u8, 170u8),
+        };
+
+        let mut line = [0u8; 520];
+        let plen = prefix.len();
+        line[..plen].copy_from_slice(prefix.as_bytes());
+        let tlen = text.len().min(512);
+        line[plen..plen + tlen].copy_from_slice(&text.as_bytes()[..tlen]);
+        let full_len = plen + tlen;
+        let display = core::str::from_utf8(&line[..full_len]).unwrap_or(text);
+        canvas_text(18.0, y, 13.0, pr, pg, pb, 255, display);
+    }
+
+    // ── Message compose row ───────────────────────────────────────────────
+    let compose_y = h - 42.0;
+    canvas_rect(0.0, compose_y - 4.0, w, 46.0, 26, 34, 54, 255);
+
+    let input_val = ui_text_input(3, 14.0, compose_y, w - 110.0, s.message_text());
+    {
+        let bytes = input_val.as_bytes();
+        let len = bytes.len().min(MSG_BUF_SIZE - 1);
+        s.msg_buf[..len].copy_from_slice(&bytes[..len]);
+        s.msg_len = len;
+    }
+
+    let can_send = s.ws_id > 0 && ws_ready_state(s.ws_id) == WS_OPEN && s.msg_len > 0;
+    if ui_button(4, w - 90.0, compose_y, 76.0, 28.0, "Send") && can_send {
+        let text = {
+            let mut tmp = [0u8; MSG_BUF_SIZE];
+            tmp[..s.msg_len].copy_from_slice(&s.msg_buf[..s.msg_len]);
+            (tmp, s.msg_len)
+        };
+        let text_str = core::str::from_utf8(&text.0[..text.1]).unwrap_or("");
+        ws_send_text(s.ws_id, text_str);
+        s.push_log(1, text_str);
+        // Clear input after send.
+        s.msg_len = 0;
+        s.msg_buf = [0u8; MSG_BUF_SIZE];
+    }
+}
+
+/// Format the first few bytes of a binary frame for display.
+fn format_bytes_preview(data: &[u8]) -> alloc::string::String {
+    let preview_len = data.len().min(16);
+    let mut s = alloc::string::String::from("[binary] ");
+    for byte in &data[..preview_len] {
+        let hi = byte >> 4;
+        let lo = byte & 0xF;
+        s.push(hex_char(hi));
+        s.push(hex_char(lo));
+        s.push(' ');
+    }
+    if data.len() > 16 {
+        s.push('…');
+    }
+    s
+}
+
+fn hex_char(n: u8) -> char {
+    if n < 10 {
+        (b'0' + n) as char
+    } else {
+        (b'a' + n - 10) as char
+    }
+}
+
+extern crate alloc;

--- a/oxide-browser/Cargo.toml
+++ b/oxide-browser/Cargo.toml
@@ -44,6 +44,7 @@ webrtc = "0.17.1"
 bytes = "1.11.1"
 serde_json = "1.0.149"
 futures-util = "0.3"
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -166,6 +166,8 @@ pub struct HostState {
     pub gpu: Arc<Mutex<Option<crate::gpu::GpuState>>>,
     /// WebRTC peer connections, data channels, and signaling (lazily initialised on first RTC call).
     pub rtc: Arc<Mutex<Option<crate::rtc::RtcState>>>,
+    /// WebSocket connections (lazily initialised on first ws call).
+    pub ws: Arc<Mutex<Option<crate::websocket::WsState>>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -533,6 +535,7 @@ impl Default for HostState {
             )),
             gpu: Arc::new(Mutex::new(None)),
             rtc: Arc::new(Mutex::new(None)),
+            ws: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -3462,6 +3465,9 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
 
     // ── WebRTC / Real-Time Communication API ─────────────────────────
     crate::rtc::register_rtc_functions(linker)?;
+
+    // ── WebSocket API ─────────────────────────────────────────────────
+    crate::websocket::register_ws_functions(linker)?;
 
     Ok(())
 }

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -110,6 +110,7 @@ pub mod ui;
 pub mod url;
 pub mod video;
 pub mod video_format;
+pub mod websocket;
 
 /// GPU-accelerated UI framework used by the desktop shell (see [GPUI](https://www.gpui.rs/)).
 ///

--- a/oxide-browser/src/websocket.rs
+++ b/oxide-browser/src/websocket.rs
@@ -1,0 +1,412 @@
+//! Host-side WebSocket connections for Oxide guest modules.
+//!
+//! Guests call the `api_ws_*` imports to open connections, send messages, poll
+//! for incoming messages, query connection state, and close connections.
+//! All I/O is non-blocking from the guest's perspective: the host spins up a
+//! tokio task per connection that drives the underlying `tokio-tungstenite`
+//! stream, pushes received frames into a `VecDeque`, and forwards outgoing
+//! frames from an mpsc channel.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use futures_util::{SinkExt, StreamExt};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use wasmtime::{Caller, Linker};
+
+use crate::capabilities::{
+    console_log, read_guest_bytes, read_guest_string, write_guest_bytes, ConsoleLevel, HostState,
+};
+
+// ── Ready-state constants (mirrors browser WebSocket.readyState) ──────────
+
+/// Connection is being established.
+pub const WS_CONNECTING: u32 = 0;
+/// Connection is open and ready to communicate.
+pub const WS_OPEN: u32 = 1;
+/// Connection is in the process of closing.
+pub const WS_CLOSING: u32 = 2;
+/// Connection is closed or could not be opened.
+pub const WS_CLOSED: u32 = 3;
+
+/// A queued incoming message (text or binary frame).
+struct RecvMsg {
+    is_binary: bool,
+    data: Vec<u8>,
+}
+
+/// An outgoing message queued by the guest for the writer task.
+enum SendMsg {
+    Data { is_binary: bool, data: Vec<u8> },
+    Close,
+}
+
+/// Per-connection state shared between the host API and the background task.
+struct WsConn {
+    /// Sender half of the outgoing message channel consumed by the writer task.
+    send_tx: mpsc::UnboundedSender<SendMsg>,
+    /// Incoming frames pushed by the reader task, drained by `api_ws_recv`.
+    recv_queue: Arc<Mutex<VecDeque<RecvMsg>>>,
+    /// Current connection state (one of the `WS_*` constants above).
+    ready_state: Arc<Mutex<u32>>,
+}
+
+/// All WebSocket state for a tab. Lazily initialised on the first `api_ws_*` call.
+pub struct WsState {
+    runtime: Runtime,
+    connections: HashMap<u32, WsConn>,
+    next_id: u32,
+}
+
+impl WsState {
+    pub fn new() -> Option<Self> {
+        let runtime = Runtime::new().ok()?;
+        Some(Self {
+            runtime,
+            connections: HashMap::new(),
+            next_id: 1,
+        })
+    }
+
+    fn alloc_id(&mut self) -> u32 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        id
+    }
+
+    /// Open a new WebSocket connection to `url`.
+    ///
+    /// Returns a handle (`> 0`) on success or `0` if the URL is invalid.
+    /// The actual TCP/TLS handshake happens asynchronously; poll
+    /// [`WsState::ready_state`] until it reaches [`WS_OPEN`].
+    fn connect(&mut self, url: &str) -> u32 {
+        let url = url.to_string();
+        let id = self.alloc_id();
+
+        let ready_state = Arc::new(Mutex::new(WS_CONNECTING));
+        let recv_queue: Arc<Mutex<VecDeque<RecvMsg>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let (send_tx, mut send_rx) = mpsc::unbounded_channel::<SendMsg>();
+
+        let rs = ready_state.clone();
+        let rq = recv_queue.clone();
+
+        self.runtime.spawn(async move {
+            let ws_stream = match connect_async(&url).await {
+                Ok((stream, _)) => stream,
+                Err(_) => {
+                    *rs.lock().unwrap() = WS_CLOSED;
+                    return;
+                }
+            };
+
+            *rs.lock().unwrap() = WS_OPEN;
+            let (mut writer, mut reader) = ws_stream.split();
+
+            // Drive reading and writing concurrently.
+            loop {
+                tokio::select! {
+                    // Incoming frame from the remote server.
+                    msg = reader.next() => {
+                        match msg {
+                            Some(Ok(Message::Text(text))) => {
+                                rq.lock().unwrap().push_back(RecvMsg {
+                                    is_binary: false,
+                                    data: text.into_bytes(),
+                                });
+                            }
+                            Some(Ok(Message::Binary(bytes))) => {
+                                rq.lock().unwrap().push_back(RecvMsg {
+                                    is_binary: true,
+                                    data: bytes.to_vec(),
+                                });
+                            }
+                            Some(Ok(Message::Close(_))) | None => {
+                                *rs.lock().unwrap() = WS_CLOSED;
+                                break;
+                            }
+                            Some(Ok(Message::Ping(payload))) => {
+                                let _ = writer.send(Message::Pong(payload)).await;
+                            }
+                            _ => {}
+                        }
+                    }
+                    // Outgoing frame queued by the guest.
+                    outgoing = send_rx.recv() => {
+                        match outgoing {
+                            Some(SendMsg::Data { is_binary, data }) => {
+                                let msg = if is_binary {
+                                    Message::Binary(data)
+                                } else {
+                                    match String::from_utf8(data) {
+                                        Ok(text) => Message::Text(text),
+                                        Err(e) => Message::Binary(e.into_bytes()),
+                                    }
+                                };
+                                if writer.send(msg).await.is_err() {
+                                    *rs.lock().unwrap() = WS_CLOSED;
+                                    break;
+                                }
+                            }
+                            Some(SendMsg::Close) => {
+                                *rs.lock().unwrap() = WS_CLOSING;
+                                let _ = writer.send(Message::Close(None)).await;
+                                *rs.lock().unwrap() = WS_CLOSED;
+                                break;
+                            }
+                            None => {
+                                // Channel closed — host dropped the connection handle.
+                                *rs.lock().unwrap() = WS_CLOSED;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        self.connections.insert(
+            id,
+            WsConn {
+                send_tx,
+                recv_queue,
+                ready_state,
+            },
+        );
+
+        id
+    }
+
+    fn send(&self, id: u32, data: Vec<u8>, is_binary: bool) -> bool {
+        if let Some(conn) = self.connections.get(&id) {
+            conn.send_tx.send(SendMsg::Data { is_binary, data }).is_ok()
+        } else {
+            false
+        }
+    }
+
+    fn recv(&self, id: u32) -> Option<RecvMsg> {
+        self.connections
+            .get(&id)?
+            .recv_queue
+            .lock()
+            .unwrap()
+            .pop_front()
+    }
+
+    fn ready_state(&self, id: u32) -> u32 {
+        self.connections
+            .get(&id)
+            .map(|c| *c.ready_state.lock().unwrap())
+            .unwrap_or(WS_CLOSED)
+    }
+
+    fn close(&mut self, id: u32) -> bool {
+        if let Some(conn) = self.connections.get(&id) {
+            *conn.ready_state.lock().unwrap() = WS_CLOSING;
+            let _ = conn.send_tx.send(SendMsg::Close);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        self.connections.remove(&id);
+    }
+}
+
+fn ensure_ws(state: &Arc<Mutex<Option<WsState>>>) -> bool {
+    let mut g = state.lock().unwrap();
+    if g.is_none() {
+        *g = WsState::new();
+    }
+    g.is_some()
+}
+
+/// Register all `api_ws_*` host functions on the given linker.
+pub fn register_ws_functions(linker: &mut Linker<HostState>) -> Result<()> {
+    // ── ws_connect ────────────────────────────────────────────────────────
+    // api_ws_connect(url_ptr: u32, url_len: u32) -> u32
+    //   Returns a connection handle (> 0), or 0 on error.
+    linker.func_wrap(
+        "oxide",
+        "api_ws_connect",
+        |caller: Caller<'_, HostState>, url_ptr: u32, url_len: u32| -> u32 {
+            let console = caller.data().console.clone();
+            let ws = caller.data().ws.clone();
+            if !ensure_ws(&ws) {
+                console_log(&console, ConsoleLevel::Error, "[WS] Init failed".into());
+                return 0;
+            }
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let url = match read_guest_string(&mem, &caller, url_ptr, url_len) {
+                Ok(s) => s,
+                Err(_) => return 0,
+            };
+            let id = ws.lock().unwrap().as_mut().unwrap().connect(&url);
+            console_log(
+                &console,
+                ConsoleLevel::Log,
+                format!("[WS] Connecting to {url} (id={id})"),
+            );
+            id
+        },
+    )?;
+
+    // ── ws_send_text ──────────────────────────────────────────────────────
+    // api_ws_send_text(id: u32, data_ptr: u32, data_len: u32) -> i32
+    //   Returns 0 on success, -1 if the connection is unknown or closed.
+    linker.func_wrap(
+        "oxide",
+        "api_ws_send_text",
+        |caller: Caller<'_, HostState>, id: u32, ptr: u32, len: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let data = match read_guest_bytes(&mem, &caller, ptr, len) {
+                Ok(b) => b,
+                Err(_) => return -1,
+            };
+            let ws = caller.data().ws.clone();
+            let g = ws.lock().unwrap();
+            if let Some(ref state) = *g {
+                if state.send(id, data, false) {
+                    0
+                } else {
+                    -1
+                }
+            } else {
+                -1
+            }
+        },
+    )?;
+
+    // ── ws_send_binary ────────────────────────────────────────────────────
+    // api_ws_send_binary(id: u32, data_ptr: u32, data_len: u32) -> i32
+    linker.func_wrap(
+        "oxide",
+        "api_ws_send_binary",
+        |caller: Caller<'_, HostState>, id: u32, ptr: u32, len: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let data = match read_guest_bytes(&mem, &caller, ptr, len) {
+                Ok(b) => b,
+                Err(_) => return -1,
+            };
+            let ws = caller.data().ws.clone();
+            let g = ws.lock().unwrap();
+            if let Some(ref state) = *g {
+                if state.send(id, data, true) {
+                    0
+                } else {
+                    -1
+                }
+            } else {
+                -1
+            }
+        },
+    )?;
+
+    // ── ws_recv ───────────────────────────────────────────────────────────
+    // api_ws_recv(id: u32, out_ptr: u32, out_cap: u32) -> i64
+    //
+    // Dequeues one frame and writes its bytes into guest memory at `out_ptr`.
+    // Return value encoding (same pattern as other APIs):
+    //   -1          : no message available (queue is empty)
+    //   >= 0        : low 32 bits = byte length written;
+    //                 bit 32 set   = frame is binary (bit 32 = 0 → text)
+    linker.func_wrap(
+        "oxide",
+        "api_ws_recv",
+        |mut caller: Caller<'_, HostState>, id: u32, out_ptr: u32, out_cap: u32| -> i64 {
+            let ws = caller.data().ws.clone();
+            let msg = {
+                let g = ws.lock().unwrap();
+                g.as_ref().and_then(|s| s.recv(id))
+            };
+            let msg = match msg {
+                Some(m) => m,
+                None => return -1,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let to_write = if msg.data.len() > out_cap as usize {
+                &msg.data[..out_cap as usize]
+            } else {
+                &msg.data
+            };
+            if write_guest_bytes(&mem, &mut caller, out_ptr, to_write).is_err() {
+                return -1;
+            }
+            let len = to_write.len() as i64;
+            if msg.is_binary {
+                len | (1i64 << 32)
+            } else {
+                len
+            }
+        },
+    )?;
+
+    // ── ws_ready_state ────────────────────────────────────────────────────
+    // api_ws_ready_state(id: u32) -> u32
+    //   0=CONNECTING  1=OPEN  2=CLOSING  3=CLOSED
+    linker.func_wrap(
+        "oxide",
+        "api_ws_ready_state",
+        |caller: Caller<'_, HostState>, id: u32| -> u32 {
+            let ws = caller.data().ws.clone();
+            let g = ws.lock().unwrap();
+            g.as_ref().map(|s| s.ready_state(id)).unwrap_or(WS_CLOSED)
+        },
+    )?;
+
+    // ── ws_close ──────────────────────────────────────────────────────────
+    // api_ws_close(id: u32) -> i32
+    //   Returns 1 if the close was initiated, 0 if the id is unknown.
+    linker.func_wrap(
+        "oxide",
+        "api_ws_close",
+        |caller: Caller<'_, HostState>, id: u32| -> i32 {
+            let ws = caller.data().ws.clone();
+            let mut g = ws.lock().unwrap();
+            if let Some(ref mut state) = *g {
+                if state.close(id) {
+                    1
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        },
+    )?;
+
+    // ── ws_remove ─────────────────────────────────────────────────────────
+    // api_ws_remove(id: u32)
+    //   Frees host-side resources for a closed connection.
+    linker.func_wrap(
+        "oxide",
+        "api_ws_remove",
+        |caller: Caller<'_, HostState>, id: u32| {
+            let ws = caller.data().ws.clone();
+            let mut g = ws.lock().unwrap();
+            if let Some(ref mut state) = *g {
+                state.remove(id);
+            }
+        },
+    )?;
+
+    Ok(())
+}

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -96,6 +96,7 @@
 //! | **Video** | [`video_load`], [`video_load_url`], [`video_render`], [`video_play`], [`video_hls_open_variant`], [`subtitle_load_srt`] |
 //! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`] |
 //! | **WebRTC** | [`rtc_create_peer`], [`rtc_create_offer`], [`rtc_create_answer`], [`rtc_create_data_channel`], [`rtc_send`], [`rtc_recv`], [`rtc_signal_connect`] |
+//! | **WebSocket** | [`ws_connect`], [`ws_send_text`], [`ws_send_binary`], [`ws_recv`], [`ws_ready_state`], [`ws_close`], [`ws_remove`] |
 //! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
 //! | **Input** | [`mouse_position`], [`mouse_button_down`], [`mouse_button_clicked`], [`key_down`], [`key_pressed`], [`scroll_delta`], [`modifiers`] |
@@ -725,6 +726,29 @@ extern "C" {
 
     #[link_name = "api_rtc_signal_recv"]
     fn _api_rtc_signal_recv(out_ptr: u32, out_cap: u32) -> i32;
+
+    // ── WebSocket API ────────────────────────────────────────────────
+
+    #[link_name = "api_ws_connect"]
+    fn _api_ws_connect(url_ptr: u32, url_len: u32) -> u32;
+
+    #[link_name = "api_ws_send_text"]
+    fn _api_ws_send_text(id: u32, data_ptr: u32, data_len: u32) -> i32;
+
+    #[link_name = "api_ws_send_binary"]
+    fn _api_ws_send_binary(id: u32, data_ptr: u32, data_len: u32) -> i32;
+
+    #[link_name = "api_ws_recv"]
+    fn _api_ws_recv(id: u32, out_ptr: u32, out_cap: u32) -> i64;
+
+    #[link_name = "api_ws_ready_state"]
+    fn _api_ws_ready_state(id: u32) -> u32;
+
+    #[link_name = "api_ws_close"]
+    fn _api_ws_close(id: u32) -> i32;
+
+    #[link_name = "api_ws_remove"]
+    fn _api_ws_remove(id: u32);
 
     // ── URL Utilities ───────────────────────────────────────────────
 
@@ -1889,6 +1913,99 @@ pub fn rtc_signal_recv() -> Option<Vec<u8>> {
     } else {
         Some(buf[..n as usize].to_vec())
     }
+}
+
+// ─── WebSocket API ───────────────────────────────────────────────────────────
+
+/// WebSocket ready-state: connection is being established.
+pub const WS_CONNECTING: u32 = 0;
+/// WebSocket ready-state: connection is open and ready.
+pub const WS_OPEN: u32 = 1;
+/// WebSocket ready-state: close handshake in progress.
+pub const WS_CLOSING: u32 = 2;
+/// WebSocket ready-state: connection is closed.
+pub const WS_CLOSED: u32 = 3;
+
+/// A received WebSocket message.
+pub struct WsMessage {
+    /// `true` when the payload is raw binary; `false` for UTF-8 text.
+    pub is_binary: bool,
+    /// Frame payload.
+    pub data: Vec<u8>,
+}
+
+impl WsMessage {
+    /// Interpret the payload as a UTF-8 string.
+    pub fn text(&self) -> String {
+        String::from_utf8_lossy(&self.data).to_string()
+    }
+}
+
+/// Open a WebSocket connection to `url` (e.g. `"ws://example.com/chat"`).
+///
+/// Returns a connection handle (`> 0`) on success, or `0` on error.
+/// The connection is established asynchronously; poll [`ws_ready_state`] until
+/// it returns [`WS_OPEN`] before sending frames.
+pub fn ws_connect(url: &str) -> u32 {
+    unsafe { _api_ws_connect(url.as_ptr() as u32, url.len() as u32) }
+}
+
+/// Send a UTF-8 text frame on the given connection.
+///
+/// Returns `0` on success, `-1` if the connection is unknown or closed.
+pub fn ws_send_text(id: u32, text: &str) -> i32 {
+    unsafe { _api_ws_send_text(id, text.as_ptr() as u32, text.len() as u32) }
+}
+
+/// Send a binary frame on the given connection.
+///
+/// Returns `0` on success, `-1` if the connection is unknown or closed.
+pub fn ws_send_binary(id: u32, data: &[u8]) -> i32 {
+    unsafe { _api_ws_send_binary(id, data.as_ptr() as u32, data.len() as u32) }
+}
+
+/// Poll for the next queued incoming frame on `id`.
+///
+/// Returns `Some(WsMessage)` if a frame is available, or `None` if the queue
+/// is empty.  The internal receive buffer is 64 KB; larger frames are
+/// truncated to that size.
+pub fn ws_recv(id: u32) -> Option<WsMessage> {
+    let mut buf = vec![0u8; 64 * 1024];
+    let result = unsafe { _api_ws_recv(id, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    if result < 0 {
+        return None;
+    }
+    let len = (result & 0xFFFF_FFFF) as usize;
+    let is_binary = (result >> 32) & 1 == 1;
+    Some(WsMessage {
+        is_binary,
+        data: buf[..len].to_vec(),
+    })
+}
+
+/// Query the current ready-state of a connection.
+///
+/// Returns one of [`WS_CONNECTING`], [`WS_OPEN`], [`WS_CLOSING`], or [`WS_CLOSED`].
+pub fn ws_ready_state(id: u32) -> u32 {
+    unsafe { _api_ws_ready_state(id) }
+}
+
+/// Initiate a graceful close handshake on `id`.
+///
+/// Returns `1` if the close was initiated, `0` if the handle is unknown.
+/// After calling this function the connection will transition to [`WS_CLOSED`]
+/// asynchronously.  Call [`ws_remove`] once the state is [`WS_CLOSED`] to free
+/// host resources.
+pub fn ws_close(id: u32) -> i32 {
+    unsafe { _api_ws_close(id) }
+}
+
+/// Release host-side resources for a closed connection.
+///
+/// Call this after [`ws_ready_state`] returns [`WS_CLOSED`] to avoid resource
+/// leaks.
+pub fn ws_remove(id: u32) {
+    unsafe { _api_ws_remove(id) }
 }
 
 // ─── HTTP Fetch API ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Add guest-facing WebSocket support via tokio-tungstenite: each connection runs on the existing per-capability Tokio runtime pattern (same as WebRTC), with a background task driving the stream, an unbounded outbound queue, and a mutex- backed inbound queue polled through api_ws_recv.

Host imports (oxide module): api_ws_connect, api_ws_send_text/binary, api_ws_recv (i64 length + binary flag in high bits), api_ws_ready_state, api_ws_close, api_ws_remove. SDK exposes matching wrappers, ready-state constants, and WsMessage.

Register WsState on HostState (lazy init), wire linker in capabilities, and add examples/ws-chat as a workspace member demonstrating connect, disconnect, send, and receive. Mark WebSocket line items complete in ROADMAP.

Ignore .cursor/ in .gitignore so local Cursor rules stay out of version control.

Clippy: remove redundant .into() on Message construction in websocket.rs; use while-let and push(char) in ws-chat.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebSocket support enabling applications to connect to WebSocket servers, send and receive text and binary messages, and monitor connection states.
  * Added a WebSocket chat example demonstrating real-time messaging functionality.

* **Chores**
  * Updated project configuration to include new example module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->