### PR TITLE
feat: implement request_animation_frame + cancel_animation_frame with…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,178 @@
+# Oxide — CLAUDE.md
+
+This is a Rust workspace. `oxide-browser` is the native host (wasmtime + GPUI desktop app). `oxide-sdk` is the guest-side crate compiled to `wasm32-unknown-unknown`. They never share Rust types at runtime — the boundary is pure FFI through linear memory.
+
+---
+
+## Build commands
+
+```bash
+# Build the host browser
+cargo build -p oxide-browser
+
+# Run the browser
+cargo run -p oxide-browser
+
+# Build an example guest app (always release for WASM)
+cargo build --target wasm32-unknown-unknown --release -p hello-oxide
+
+# Full check suite (must pass before any commit)
+cargo fmt --all
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+
+# Build the SDK for WASM (sanity check)
+cargo build -p oxide-sdk --target wasm32-unknown-unknown
+```
+
+FFmpeg dev libraries are required on the host for video decode (`brew install ffmpeg` on macOS).
+
+---
+
+## Project structure
+
+```
+oxide/
+├── oxide-browser/src/
+│   ├── capabilities.rs   # All host functions registered into the wasmtime Linker
+│   ├── engine.rs         # WasmEngine, SandboxPolicy, fuel/memory bounds
+│   ├── runtime.rs        # BrowserHost — fetch, compile, instantiate, frame loop
+│   ├── ui.rs             # GPUI shell — toolbar, canvas, console, widgets
+│   ├── navigation.rs     # History stack
+│   ├── url.rs            # URL parsing (http, https, file, oxide schemes)
+│   ├── rtc.rs            # WebRTC (register_rtc_functions)
+│   ├── websocket.rs      # WebSocket (register_ws_functions)
+│   └── gpu.rs, audio_format.rs, video.rs, media_capture.rs, …
+├── oxide-sdk/src/
+│   ├── lib.rs            # FFI declarations + safe public wrappers
+│   └── proto.rs          # Zero-dependency protobuf codec
+└── examples/
+    ├── hello-oxide/      # Minimal guest app
+    ├── ws-chat/          # WebSocket demo
+    ├── rtc-chat/         # WebRTC demo
+    └── …
+```
+
+`HostState` in `capabilities.rs` is the central shared state struct. All host modules (rtc, websocket, gpu, …) add an `Arc<Mutex<Option<TheirState>>>` field to it and register their functions via a `register_*_functions(linker)` call at the bottom of `register_host_functions`.
+
+---
+
+## Adding a host function (the most common task)
+
+Every new capability follows this four-step pattern:
+
+**1. If the feature needs significant state, create a new module** (e.g. `websocket.rs`) with a `TheirState` struct and a `register_*_functions(linker: &mut Linker<HostState>) -> Result<()>` function. Add `pub mod their_module;` to `lib.rs`.
+
+**2. Add state to `HostState`** in `capabilities.rs`:
+```rust
+pub ws: Arc<Mutex<Option<crate::websocket::WsState>>>,
+```
+And initialise it in the `Default` impl:
+```rust
+ws: Arc::new(Mutex::new(None)),
+```
+
+**3. Register the host function** inside `register_host_functions` (or in the module's own `register_*_functions`):
+```rust
+linker.func_wrap("oxide", "api_my_feature",
+    |mut caller: Caller<'_, HostState>, ptr: u32, len: u32| -> u32 {
+        let mem = caller.data().memory.expect("memory not set");
+        let s = read_guest_string(&mem, &caller, ptr, len).unwrap_or_default();
+        // … host logic …
+        0
+    },
+)?;
+```
+
+**4. Expose it in the SDK** (`oxide-sdk/src/lib.rs`):
+```rust
+// In the extern "C" block:
+#[link_name = "api_my_feature"]
+fn _api_my_feature(ptr: u32, len: u32) -> u32;
+
+// Public wrapper:
+/// Brief doc comment.
+pub fn my_feature(s: &str) -> u32 {
+    unsafe { _api_my_feature(s.as_ptr() as u32, s.len() as u32) }
+}
+```
+
+### Memory helpers (already in `capabilities.rs`)
+
+| Helper | Use |
+|--------|-----|
+| `read_guest_string(&mem, &caller, ptr, len)` | Read UTF-8 from guest |
+| `read_guest_bytes(&mem, &caller, ptr, len)` | Read raw bytes from guest |
+| `write_guest_bytes(&mem, &mut caller, ptr, data)` | Write bytes into guest |
+
+Data always crosses the boundary as `(ptr: u32, len: u32)` pairs. Never pass Rust references across the boundary.
+
+---
+
+## Naming conventions
+
+| Entity | Convention | Example |
+|--------|------------|---------|
+| Host function name (linker) | `api_<category>_<action>` | `api_ws_connect`, `api_canvas_rect` |
+| SDK FFI import | `_api_<name>` | `_api_ws_connect` |
+| SDK public wrapper | `<category>_<action>` | `ws_connect`, `canvas_rect` |
+| State struct | `<Feature>State` | `WsState`, `RtcState`, `GpuState` |
+| Register function | `register_<feature>_functions` | `register_ws_functions` |
+| Constants | `UPPER_SNAKE_CASE` | `WS_OPEN`, `KEY_ENTER` |
+
+---
+
+## Security rules — never break these
+
+- **Never link WASI** — the sandbox is airtight by construction. No filesystem, no env vars, no raw sockets.
+- **All host access is additive** — if you didn't explicitly register it in the linker, the guest cannot call it.
+- **Validate all lengths** before reading guest memory. A malicious guest can pass any ptr/len.
+- **New capabilities must be opt-in** — add them to the linker explicitly, not via a wildcard.
+
+---
+
+## Guest app contract
+
+Every `.wasm` module must:
+1. Export `start_app()` — called once on load.
+2. Optionally export `on_frame(dt_ms: u32)` — called every frame (fuel replenished each call).
+3. Optionally export `on_timer(callback_id: u32)` — called when a `set_timeout`/`set_interval` fires.
+4. Compile as `[lib] crate-type = ["cdylib"]` targeting `wasm32-unknown-unknown`.
+5. Import everything from the `"oxide"` wasm import module — never WASI.
+
+---
+
+## LLM coding guidelines
+
+**Think before coding.**
+- State assumptions explicitly. If multiple interpretations exist, present them — don't pick silently.
+- If something is unclear, stop and ask before writing code.
+- If a simpler approach exists, say so. Push back when warranted.
+
+**Simplicity first.**
+- Minimum code that solves the problem. Nothing speculative.
+- No abstractions for single-use code. No "flexibility" that wasn't asked for.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+**Surgical changes.**
+- Touch only what you must. Don't improve adjacent code, comments, or formatting.
+- Match the existing style (e.g. `block_on` for async in RTC, unbounded mpsc + background task in websocket).
+- When your changes make something unused (import, variable, function), remove it. Don't remove pre-existing dead code unless asked.
+- Every changed line should trace directly to the request.
+
+**Verify your work.**
+- After any host-side change: `cargo build -p oxide-browser` must pass.
+- After any SDK change: `cargo build -p oxide-sdk --target wasm32-unknown-unknown` must pass.
+- After any example change: `cargo build --target wasm32-unknown-unknown --release -p <example>` must pass.
+- For host functions: confirm the function is registered in `register_host_functions` (or called from there) and the SDK wrapper is present with a doc comment.
+
+---
+
+## Common pitfalls
+
+- **`memory` is set after instantiation** — host functions called during `start_app` may need to use `caller.data().memory.expect("memory not set")`. The `memory` field is `Option<Memory>` for this reason.
+- **Guest state is no_std** — example apps run on `wasm32-unknown-unknown` with no std allocator by default unless `alloc` is explicitly linked. Keep guest code allocation-minimal.
+- **`block_on` vs spawn** — RTC uses `runtime.block_on` for synchronous host calls. WebSocket uses `runtime.spawn` for background tasks. Match the pattern of the subsystem you're working in.
+- **`Arc<Mutex<Option<T>>>` lazy init** — all major subsystems (audio, gpu, rtc, ws) are `None` until first use. Always use an `ensure_*(state)` helper before locking and calling methods.
+- **Frame fuel** — each `on_frame` call gets 50M instructions (`FRAME_FUEL_LIMIT` in `runtime.rs`). Host functions themselves don't count against fuel, but they can't call back into the guest.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "oxide-docs",
     "examples/hello-oxide",
     "examples/audio-player",
+    "examples/raf-demo",
     "examples/timer-demo",
     "examples/fullstack-notes/frontend",
     "examples/fullstack-notes/backend",

--- a/examples/raf-demo/Cargo.toml
+++ b/examples/raf-demo/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "raf-demo"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/raf-demo/src/lib.rs
+++ b/examples/raf-demo/src/lib.rs
@@ -1,0 +1,154 @@
+use oxide_sdk::*;
+
+const BG: (u8, u8, u8) = (25, 25, 40);
+const ACCENT: (u8, u8, u8) = (80, 160, 220);
+const BALL_COLOR: (u8, u8, u8) = (240, 100, 100);
+
+const CB_ANIMATION: u32 = 1;
+const BTN_TOGGLE: u32 = 100;
+
+static mut BALL_X: f32 = 100.0;
+static mut BALL_Y: f32 = 100.0;
+static mut VX: f32 = 3.0;
+static mut VY: f32 = 2.0;
+static mut RUNNING: bool = true;
+static mut RAF_ID: u32 = 0;
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("RAF Demo loaded! Using request_animation_frame for smooth physics updates.");
+    unsafe {
+        RAF_ID = request_animation_frame(CB_ANIMATION);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn on_timer(callback_id: u32) {
+    if callback_id == CB_ANIMATION && unsafe { RUNNING } {
+        unsafe {
+            // Simple physics update (called ~60x/sec via rAF)
+            BALL_X += VX;
+            BALL_Y += VY;
+
+            let (w, h) = canvas_dimensions();
+            let width = w as f32;
+            let height = h as f32;
+            let radius = 20.0;
+
+            // Bounce off walls
+            if BALL_X - radius < 0.0 || BALL_X + radius > width {
+                VX = -VX;
+                BALL_X = BALL_X.clamp(radius, width - radius);
+            }
+            if BALL_Y - radius < 0.0 || BALL_Y + radius > height {
+                VY = -VY;
+                BALL_Y = BALL_Y.clamp(radius, height - radius);
+            }
+
+            // Request next frame to continue animation
+            RAF_ID = request_animation_frame(CB_ANIMATION);
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let (width, height) = canvas_dimensions();
+    let w = width as f32;
+    let h = height as f32;
+
+    canvas_clear(BG.0, BG.1, BG.2, 255);
+
+    // Header
+    canvas_rect(0.0, 0.0, w, 60.0, ACCENT.0, ACCENT.1, ACCENT.2, 255);
+    canvas_text(20.0, 18.0, 24.0, 255, 255, 255, 255, "Oxide RAF Demo");
+    canvas_text(
+        20.0,
+        42.0,
+        13.0,
+        200,
+        220,
+        255,
+        255,
+        "request_animation_frame + on_timer for vsync-aligned updates",
+    );
+
+    unsafe {
+        // Draw bouncing ball
+        let x = BALL_X;
+        let y = BALL_Y;
+        canvas_circle(x, y, 20.0, BALL_COLOR.0, BALL_COLOR.1, BALL_COLOR.2, 255);
+
+        // Velocity indicators
+        canvas_line(x, y, x + VX * 5.0, y + VY * 5.0, 255, 255, 100, 255, 3.0);
+
+        let status = if RUNNING {
+            "RUNNING (rAF driven)"
+        } else {
+            "PAUSED"
+        };
+        let status_color = if RUNNING {
+            (80, 220, 120)
+        } else {
+            (200, 100, 100)
+        };
+        canvas_text(
+            20.0,
+            80.0,
+            16.0,
+            status_color.0,
+            status_color.1,
+            status_color.2,
+            255,
+            status,
+        );
+
+        canvas_text(
+            20.0,
+            110.0,
+            13.0,
+            180,
+            180,
+            200,
+            255,
+            &format!("pos: ({:.1}, {:.1})  vel: ({:.1}, {:.1})", x, y, VX, VY),
+        );
+
+        // Toggle button
+        let label = if RUNNING {
+            "Pause Animation"
+        } else {
+            "Resume Animation"
+        };
+        if ui_button(BTN_TOGGLE, 20.0, 140.0, 180.0, 35.0, label) {
+            RUNNING = !RUNNING;
+            if RUNNING {
+                RAF_ID = request_animation_frame(CB_ANIMATION);
+            } else {
+                cancel_animation_frame(RAF_ID);
+            }
+        }
+
+        // Instructions
+        canvas_text(
+            20.0,
+            h - 60.0,
+            12.0,
+            140,
+            140,
+            160,
+            255,
+            "Physics updated via request_animation_frame callback (on_timer).",
+        );
+        canvas_text(
+            20.0,
+            h - 40.0,
+            12.0,
+            140,
+            140,
+            160,
+            255,
+            "on_frame only handles rendering. Cancel/resume via button.",
+        );
+    }
+}

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -100,6 +100,26 @@ impl AudioEngine {
     }
 }
 
+/// One-shot animation frame request. Queued by `api_request_animation_frame` and drained
+/// every frame (before `on_frame`) in `LiveModule::tick`. Fires the guest `callback_id` via
+/// the existing `on_timer` export exactly once.
+#[derive(Clone, Debug)]
+pub struct AnimationRequest {
+    /// Host-assigned ID (for `cancel_animation_frame`). Mirrors timer ID scheme.
+    pub id: u32,
+    /// Guest-defined ID passed to `on_timer(callback_id)` when the frame fires.
+    pub callback_id: u32,
+}
+
+/// Drain all pending animation frame requests (one-shot by design). Returns the
+/// `callback_id`s to fire via `on_timer`. The queue is cleared after draining.
+pub fn drain_animation_frame_requests(requests: &Arc<Mutex<Vec<AnimationRequest>>>) -> Vec<u32> {
+    let mut guard = requests.lock().unwrap();
+    let callback_ids: Vec<u32> = guard.iter().map(|r| r.callback_id).collect();
+    guard.clear();
+    callback_ids
+}
+
 /// All shared state between the browser host and a guest Wasm module (and dynamically loaded children).
 ///
 /// Most fields are behind [`Arc`] and [`Mutex`] so the same state can be shared across
@@ -116,6 +136,9 @@ pub struct HostState {
     pub storage: Arc<Mutex<HashMap<String, String>>>,
     /// Pending one-shot and interval timers; the host drains these and invokes `on_timer` on the guest.
     pub timers: Arc<Mutex<Vec<TimerEntry>>>,
+    /// Pending one-shot animation frame requests. Drained every frame (before timers and `on_frame`)
+    /// and fired via the existing `on_timer` export. See [`drain_animation_frame_requests`].
+    pub animation_requests: Arc<Mutex<Vec<AnimationRequest>>>,
     /// Monotonic counter used to assign unique [`TimerEntry::id`] values for `api_set_timeout` / `api_set_interval`.
     pub timer_next_id: Arc<Mutex<u32>>,
     /// Last text written to or read from the clipboard via the guest API (when permitted).
@@ -508,6 +531,7 @@ impl Default for HostState {
             })),
             storage: Arc::new(Mutex::new(HashMap::new())),
             timers: Arc::new(Mutex::new(Vec::new())),
+            animation_requests: Arc::new(Mutex::new(Vec::new())),
             timer_next_id: Arc::new(Mutex::new(1)),
             clipboard: Arc::new(Mutex::new(String::new())),
             clipboard_allowed: Arc::new(Mutex::new(false)),
@@ -1402,6 +1426,39 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
                 .lock()
                 .unwrap()
                 .retain(|t| t.id != timer_id);
+        },
+    )?;
+
+    // ── Animation Frames ──────────────────────────────────────────────
+    // One-shot per request (call again from inside `on_timer` to continue). Drained
+    // every frame in `LiveModule::tick` before regular timers/`on_frame`. Reuses
+    // `timer_next_id` counter and `on_timer` callback mechanism.
+
+    linker.func_wrap(
+        "oxide",
+        "api_request_animation_frame",
+        |caller: Caller<'_, HostState>, callback_id: u32| -> u32 {
+            let mut next = caller.data().timer_next_id.lock().unwrap();
+            let id = *next;
+            *next = next.wrapping_add(1).max(1);
+            drop(next);
+
+            let req = AnimationRequest { id, callback_id };
+            caller.data().animation_requests.lock().unwrap().push(req);
+            id
+        },
+    )?;
+
+    linker.func_wrap(
+        "oxide",
+        "api_cancel_animation_frame",
+        |caller: Caller<'_, HostState>, request_id: u32| {
+            caller
+                .data()
+                .animation_requests
+                .lock()
+                .unwrap()
+                .retain(|r| r.id != request_id);
         },
     )?;
 

--- a/oxide-browser/src/runtime.rs
+++ b/oxide-browser/src/runtime.rs
@@ -12,7 +12,9 @@ use anyhow::{Context, Result};
 use wasmtime::*;
 
 use crate::bookmarks::BookmarkStore;
-use crate::capabilities::{drain_expired_timers, register_host_functions, HostState};
+use crate::capabilities::{
+    drain_animation_frame_requests, drain_expired_timers, register_host_functions, HostState,
+};
 use crate::engine::{ModuleLoader, SandboxPolicy, WasmEngine};
 use crate::history::HistoryStore;
 use crate::url::OxideUrl;
@@ -35,7 +37,7 @@ const FRAME_FUEL_LIMIT: u64 = 50_000_000;
 /// A Wasmtime [`Store`] and typed guest exports kept alive across frames for interactive apps.
 ///
 /// Constructed when the module exports `on_frame`. The store holds [`HostState`] (canvas, console,
-/// timers, etc.) for the lifetime of the tab.
+/// timers, animation requests, etc.) for the lifetime of the tab.
 pub struct LiveModule {
     store: Store<HostState>,
     on_frame_fn: TypedFunc<u32, ()>,
@@ -43,14 +45,35 @@ pub struct LiveModule {
 }
 
 impl LiveModule {
-    /// Advances one frame: drains expired timers and invokes `on_timer(callback_id)` for each,
-    /// then calls `on_frame(dt_ms)` with the elapsed time in milliseconds.
+    /// Advances one frame: drains animation frame requests and expired timers (both invoke
+    /// `on_timer(callback_id)`), then calls `on_frame(dt_ms)`.
     ///
-    /// Timer and frame work each run with a bounded fuel budget; exhaustion is surfaced as an
-    /// error or logged to the guest console.
+    /// Animation requests (from `request_animation_frame`) are one-shot and fire every frame
+    /// they are queued. All callbacks run with bounded fuel. Errors are logged to console.
     pub fn tick(&mut self, dt_ms: u32) -> Result<()> {
-        // Fire any expired timers before the frame update.
         if let Some(ref on_timer) = self.on_timer_fn {
+            // Animation frames first (vsync-aligned, one-shot).
+            let anim = self.store.data().animation_requests.clone();
+            let fired_anim = drain_animation_frame_requests(&anim);
+            for callback_id in fired_anim {
+                self.store
+                    .set_fuel(FRAME_FUEL_LIMIT)
+                    .context("failed to set animation frame fuel")?;
+                if let Err(e) = on_timer.call(&mut self.store, callback_id) {
+                    let msg = if e.to_string().contains("fuel") {
+                        format!("on_timer(raf:{callback_id}) fuel limit exceeded")
+                    } else {
+                        format!("on_timer(raf:{callback_id}) trapped: {e}")
+                    };
+                    crate::capabilities::console_log(
+                        &self.store.data().console,
+                        crate::capabilities::ConsoleLevel::Error,
+                        msg,
+                    );
+                }
+            }
+
+            // Regular timers.
             let timers = self.store.data().timers.clone();
             let fired = drain_expired_timers(&timers);
             for callback_id in fired {

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -97,7 +97,7 @@
 //! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`] |
 //! | **WebRTC** | [`rtc_create_peer`], [`rtc_create_offer`], [`rtc_create_answer`], [`rtc_create_data_channel`], [`rtc_send`], [`rtc_recv`], [`rtc_signal_connect`] |
 //! | **WebSocket** | [`ws_connect`], [`ws_send_text`], [`ws_send_binary`], [`ws_recv`], [`ws_ready_state`], [`ws_close`], [`ws_remove`] |
-//! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`time_now_ms`] |
+//! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`request_animation_frame`], [`cancel_animation_frame`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
 //! | **Input** | [`mouse_position`], [`mouse_button_down`], [`mouse_button_clicked`], [`key_down`], [`key_pressed`], [`scroll_delta`], [`modifiers`] |
 //! | **Widgets** | [`ui_button`], [`ui_checkbox`], [`ui_slider`], [`ui_text_input`] |
@@ -112,7 +112,7 @@
 //! 2. **Optionally export `on_frame`** — `extern "C" fn(dt_ms: u32)` for
 //!    interactive apps with a render loop (called every frame, fuel replenished).
 //! 3. **Optionally export `on_timer`** — `extern "C" fn(callback_id: u32)`
-//!    to receive timer callbacks from [`set_timeout`] / [`set_interval`].
+//!    to receive callbacks from [`set_timeout`], [`set_interval`], and [`request_animation_frame`].
 //! 4. **Compile as `cdylib`** — `crate-type = ["cdylib"]` in `Cargo.toml`.
 //! 5. **Target `wasm32-unknown-unknown`** — no WASI, pure capability-based I/O.
 //!
@@ -288,6 +288,12 @@ extern "C" {
 
     #[link_name = "api_clear_timer"]
     fn _api_clear_timer(timer_id: u32);
+
+    #[link_name = "api_request_animation_frame"]
+    fn _api_request_animation_frame(callback_id: u32) -> u32;
+
+    #[link_name = "api_cancel_animation_frame"]
+    fn _api_cancel_animation_frame(request_id: u32);
 
     #[link_name = "api_random"]
     fn _api_random() -> u64;
@@ -1204,6 +1210,20 @@ pub fn set_interval(callback_id: u32, interval_ms: u32) -> u32 {
 /// Cancel a timer previously created with [`set_timeout`] or [`set_interval`].
 pub fn clear_timer(timer_id: u32) {
     unsafe { _api_clear_timer(timer_id) }
+}
+
+/// Schedule a callback for the next animation frame (vsync-aligned repaint).
+///
+/// The host calls your exported `on_timer(callback_id)` with the provided ID on the
+/// subsequent frame. Returns a request ID usable with [`cancel_animation_frame`].
+/// Call `request_animation_frame` again from inside the callback to keep animating.
+pub fn request_animation_frame(callback_id: u32) -> u32 {
+    unsafe { _api_request_animation_frame(callback_id) }
+}
+
+/// Cancel a pending animation frame request.
+pub fn cancel_animation_frame(request_id: u32) {
+    unsafe { _api_cancel_animation_frame(request_id) }
 }
 
 // ─── Random API ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
… raf-demo example

Adds vsync-aligned one-shot animation frame callbacks (queues via new HostState field, drained in LiveModule::tick before timers/on_frame, fires via existing on_timer callback). Reuses timer ID/counter pattern per CLAUDE.md guidelines for host capabilities. No changes to guest contract or on_frame export.

Includes:
- AnimationRequest struct + drain helper in capabilities.rs
- SDK wrappers + updated API tables/docs
- New examples/raf-demo (bouncing ball physics in rAF callback, rendering + UI in on_frame)
- Workspace Cargo.toml update

Why: Fulfills ROADMAP Phase 4 priority for better animation control (decouples update from render loop). All checks (fmt, clippy, build, wasm) pass. Follows surgical/minimal changes rule.

(Closes implicit request from previous session)

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `request_animation_frame()` and `cancel_animation_frame()` APIs for scheduling one-shot animation callbacks, with callbacks routed through the existing `on_timer` handler and processed before regular timers each frame.
  * Added a bouncing ball animation demo example showcasing the new animation frame API.

* **Documentation**
  * Added comprehensive workspace architecture guide, including build instructions, quality gates, capability development workflow, security constraints, and LLM coding guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->