### PR TITLE
feat: implement MIDI device API with piano visualizer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ members = [
     "examples/gpu-graphics-demo",
     "examples/rtc-chat",
     "examples/ws-chat",
+    "examples/midi-demo",
 ]
 resolver = "2"

--- a/examples/midi-demo/Cargo.toml
+++ b/examples/midi-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "midi-demo"
+version = "0.1.0"
+edition = "2021"
+description = "MIDI monitor and piano visualizer for the Oxide browser"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/midi-demo/src/lib.rs
+++ b/examples/midi-demo/src/lib.rs
@@ -1,0 +1,574 @@
+//! MIDI monitor and piano keyboard visualizer for the Oxide browser.
+//!
+//! Demonstrates the Oxide MIDI API: enumerate input/output devices, open a
+//! connection, receive note-on/off and CC messages in real time, and render
+//! an interactive piano keyboard that lights up as notes arrive.
+//!
+//! # Building
+//!
+//! ```bash
+//! cargo build --target wasm32-unknown-unknown --release -p midi-demo
+//! ```
+//!
+//! Then open `target/wasm32-unknown-unknown/release/midi_demo.wasm` in Oxide.
+
+use oxide_sdk::*;
+
+// ── Layout constants ──────────────────────────────────────────────────────────
+
+const HEADER_H: f32 = 48.0;
+const DEVICE_PANEL_H: f32 = 110.0;
+const LOG_H: f32 = 200.0;
+const PIANO_H: f32 = 110.0;
+
+// Piano: show C2–B5 (MIDI notes 36–83), 4 octaves = 28 white keys
+const PIANO_START_NOTE: u8 = 36; // C2
+const PIANO_END_NOTE: u8 = 83; // B5
+const WHITE_KEY_W: f32 = 22.0;
+const WHITE_KEY_H: f32 = 80.0;
+const BLACK_KEY_W: f32 = 13.0;
+const BLACK_KEY_H: f32 = 50.0;
+
+// Message log ring buffer
+const LOG_SIZE: usize = 16;
+const MSG_LEN: usize = 64;
+
+// Max MIDI devices shown
+const MAX_DEVICES: usize = 8;
+const DEV_NAME_LEN: usize = 64;
+// Max MIDI message size for stack buffers
+const MIDI_MSG_MAX: usize = 16;
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+struct AppState {
+    // Device list (scanned once in start_app)
+    input_count: u32,
+    input_names: [[u8; DEV_NAME_LEN]; MAX_DEVICES],
+    input_name_lens: [usize; MAX_DEVICES],
+
+    // Active connection
+    port_handle: u32,
+    connected_idx: i32, // -1 = none
+
+    // Note state: true = held
+    active_notes: [bool; 128],
+
+    // Message log ring buffer: (text bytes, len)
+    log: [[u8; MSG_LEN]; LOG_SIZE],
+    log_lens: [usize; LOG_SIZE],
+    log_head: usize, // index of oldest entry
+    log_count: usize,
+}
+
+impl AppState {
+    const fn new() -> Self {
+        Self {
+            input_count: 0,
+            input_names: [[0u8; DEV_NAME_LEN]; MAX_DEVICES],
+            input_name_lens: [0usize; MAX_DEVICES],
+            port_handle: 0,
+            connected_idx: -1,
+            active_notes: [false; 128],
+            log: [[0u8; MSG_LEN]; LOG_SIZE],
+            log_lens: [0usize; LOG_SIZE],
+            log_head: 0,
+            log_count: 0,
+        }
+    }
+
+    fn push_log(&mut self, text: &str) {
+        let slot = (self.log_head + self.log_count) % LOG_SIZE;
+        let bytes = text.as_bytes();
+        let len = bytes.len().min(MSG_LEN);
+        self.log[slot][..len].copy_from_slice(&bytes[..len]);
+        self.log_lens[slot] = len;
+        if self.log_count < LOG_SIZE {
+            self.log_count += 1;
+        } else {
+            // Ring is full — advance head to drop oldest
+            self.log_head = (self.log_head + 1) % LOG_SIZE;
+        }
+    }
+
+    fn log_entry(&self, age: usize) -> &str {
+        // age=0 is newest
+        let count = self.log_count;
+        if age >= count {
+            return "";
+        }
+        let idx = (self.log_head + count - 1 - age) % LOG_SIZE;
+        let len = self.log_lens[idx];
+        core::str::from_utf8(&self.log[idx][..len]).unwrap_or("")
+    }
+
+    fn device_name(&self, idx: usize) -> &str {
+        if idx >= MAX_DEVICES {
+            return "";
+        }
+        let len = self.input_name_lens[idx];
+        core::str::from_utf8(&self.input_names[idx][..len]).unwrap_or("")
+    }
+}
+
+static mut STATE: AppState = AppState::new();
+
+// ── Entry points ──────────────────────────────────────────────────────────────
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    let s = unsafe { &mut *core::ptr::addr_of_mut!(STATE) };
+
+    let count = midi_input_count().min(MAX_DEVICES as u32);
+    s.input_count = count;
+    for i in 0..count as usize {
+        let name = midi_input_name(i as u32);
+        let bytes = name.as_bytes();
+        let len = bytes.len().min(DEV_NAME_LEN);
+        s.input_names[i][..len].copy_from_slice(&bytes[..len]);
+        s.input_name_lens[i] = len;
+    }
+
+    if count == 0 {
+        log("MIDI Demo: no input devices found");
+    } else {
+        log(&format!("MIDI Demo: {} input device(s) found", count));
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let s = unsafe { &mut *core::ptr::addr_of_mut!(STATE) };
+    let (w_u, h_u) = canvas_dimensions();
+    let w = w_u as f32;
+    let h = h_u as f32;
+
+    // Drain incoming MIDI messages (up to 32 per frame to avoid stalling).
+    if s.port_handle > 0 {
+        for _ in 0..32 {
+            match midi_recv(s.port_handle) {
+                Some(data) => {
+                    // Copy into a fixed-size stack array to release the Vec
+                    // before mutably borrowing `s` in handle_midi_message.
+                    let mut buf = [0u8; MIDI_MSG_MAX];
+                    let len = data.len().min(MIDI_MSG_MAX);
+                    buf[..len].copy_from_slice(&data[..len]);
+                    handle_midi_message(s, &buf[..len]);
+                }
+                None => break,
+            }
+        }
+    }
+
+    // ── Background ────────────────────────────────────────────────────────
+    canvas_clear(18, 22, 36, 255);
+
+    // ── Header ────────────────────────────────────────────────────────────
+    canvas_rect(0.0, 0.0, w, HEADER_H, 28, 36, 60, 255);
+    canvas_text(16.0, 13.0, 22.0, 160, 200, 255, 255, "Oxide MIDI Monitor");
+    let status_text = if s.port_handle > 0 {
+        "CONNECTED"
+    } else {
+        "DISCONNECTED"
+    };
+    let (sr, sg, sb) = if s.port_handle > 0 {
+        (40u8, 200u8, 100u8)
+    } else {
+        (120u8, 120u8, 140u8)
+    };
+    canvas_rounded_rect(w - 140.0, 12.0, 126.0, 24.0, 12.0, sr, sg, sb, 40);
+    canvas_text(w - 132.0, 17.0, 13.0, sr, sg, sb, 255, status_text);
+
+    // ── Device panel ──────────────────────────────────────────────────────
+    let dev_y = HEADER_H + 4.0;
+    canvas_text(
+        16.0,
+        dev_y + 4.0,
+        13.0,
+        140,
+        150,
+        180,
+        255,
+        "Input Devices:",
+    );
+
+    if s.input_count == 0 {
+        canvas_text(
+            16.0,
+            dev_y + 22.0,
+            13.0,
+            100,
+            110,
+            130,
+            255,
+            "No MIDI input devices found. Connect a device and reload.",
+        );
+    } else {
+        let btn_y = dev_y + 20.0;
+        for i in 0..s.input_count as usize {
+            let btn_x = 16.0 + i as f32 * 190.0;
+            let is_active = s.connected_idx == i as i32;
+
+            // Copy name into a local stack buffer so we don't hold a borrow
+            // on `s` while calling SDK functions that need `&mut s`.
+            let mut name_buf = [0u8; DEV_NAME_LEN];
+            let name_len = {
+                let name_bytes = s.device_name(i).as_bytes();
+                let len = name_bytes.len().min(DEV_NAME_LEN);
+                name_buf[..len].copy_from_slice(&name_bytes[..len]);
+                len
+            };
+            let name = core::str::from_utf8(&name_buf[..name_len]).unwrap_or("");
+
+            let (br, bg, bb) = if is_active {
+                (50u8, 140u8, 220u8)
+            } else {
+                (40u8, 50u8, 80u8)
+            };
+            canvas_rounded_rect(btn_x, btn_y, 178.0, 32.0, 6.0, br, bg, bb, 255);
+            let display = if name.len() > 22 { &name[..22] } else { name };
+            canvas_text(btn_x + 8.0, btn_y + 8.0, 13.0, 230, 235, 255, 255, display);
+
+            if ui_button((10 + i) as u32, btn_x, btn_y, 178.0, 32.0, "") {
+                if is_active {
+                    midi_close(s.port_handle);
+                    s.port_handle = 0;
+                    s.connected_idx = -1;
+                    s.active_notes = [false; 128];
+                    s.push_log("Disconnected");
+                } else {
+                    if s.port_handle > 0 {
+                        midi_close(s.port_handle);
+                        s.active_notes = [false; 128];
+                    }
+                    let h = midi_open_input(i as u32);
+                    s.port_handle = h;
+                    if h > 0 {
+                        s.connected_idx = i as i32;
+                        let mut msg = [0u8; 80];
+                        let prefix = b"Connected to: ";
+                        let plen = prefix.len();
+                        let nlen = name_len.min(80 - plen);
+                        msg[..plen].copy_from_slice(prefix);
+                        msg[plen..plen + nlen].copy_from_slice(&name_buf[..nlen]);
+                        let full = core::str::from_utf8(&msg[..plen + nlen]).unwrap_or("");
+                        s.push_log(full);
+                    } else {
+                        s.connected_idx = -1;
+                        s.push_log("Failed to open MIDI device");
+                    }
+                }
+            }
+        }
+    }
+
+    // Hint text below device buttons
+    if s.input_count > 0 {
+        canvas_text(
+            16.0,
+            dev_y + 60.0,
+            12.0,
+            100,
+            110,
+            130,
+            255,
+            "Click a device button to connect / disconnect.",
+        );
+    }
+
+    // ── Message log ───────────────────────────────────────────────────────
+    let log_y = HEADER_H + DEVICE_PANEL_H;
+    canvas_rect(0.0, log_y, w, LOG_H, 14, 18, 30, 255);
+    canvas_text(16.0, log_y + 6.0, 13.0, 140, 150, 180, 255, "Messages:");
+
+    let line_h = 18.0;
+    let visible = ((LOG_H - 26.0) / line_h) as usize;
+    for i in 0..visible.min(s.log_count) {
+        let text = s.log_entry(i);
+        let y = log_y + 24.0 + i as f32 * line_h;
+        let (r, g, b) = log_color(text);
+        canvas_text(16.0, y, 13.0, r, g, b, 255, text);
+    }
+    if s.log_count == 0 {
+        canvas_text(
+            16.0,
+            log_y + 28.0,
+            13.0,
+            70,
+            80,
+            100,
+            255,
+            "Waiting for MIDI messages…",
+        );
+    }
+
+    // ── Piano keyboard ────────────────────────────────────────────────────
+    let piano_y = h - PIANO_H - 8.0;
+    draw_piano(s, 16.0, piano_y, w);
+}
+
+// ── MIDI message handler ──────────────────────────────────────────────────────
+
+fn handle_midi_message(s: &mut AppState, msg: &[u8]) {
+    if msg.is_empty() {
+        return;
+    }
+    let status = msg[0];
+    let kind = status & 0xF0;
+    let ch = (status & 0x0F) + 1;
+
+    match kind {
+        0x90 if msg.len() >= 3 => {
+            let note = msg[1];
+            let vel = msg[2];
+            if vel > 0 {
+                s.active_notes[note as usize] = true;
+                let text = format_note_on(ch, note, vel);
+                s.push_log(&text);
+            } else {
+                // Note On with vel=0 is a Note Off
+                s.active_notes[note as usize] = false;
+                let text = format_note_off(ch, note);
+                s.push_log(&text);
+            }
+        }
+        0x80 if msg.len() >= 3 => {
+            let note = msg[1];
+            s.active_notes[note as usize] = false;
+            let text = format_note_off(ch, msg[1]);
+            s.push_log(&text);
+        }
+        0xB0 if msg.len() >= 3 => {
+            let cc = msg[1];
+            let val = msg[2];
+            let mut buf = [0u8; 48];
+            let text = format_cc(&mut buf, ch, cc, val);
+            s.push_log(text);
+        }
+        0xC0 if msg.len() >= 2 => {
+            let mut buf = [0u8; 32];
+            let text = format_prog(&mut buf, ch, msg[1]);
+            s.push_log(text);
+        }
+        0xE0 if msg.len() >= 3 => {
+            let lsb = msg[1] as i16;
+            let msb = msg[2] as i16;
+            let bend = ((msb << 7) | lsb) - 8192;
+            let mut buf = [0u8; 32];
+            let text = format_pitchbend(&mut buf, ch, bend);
+            s.push_log(text);
+        }
+        _ => {
+            // Unknown / SysEx — show raw hex
+            let mut buf = [0u8; 48];
+            let n = format_hex(&mut buf, msg);
+            let text = core::str::from_utf8(&buf[..n]).unwrap_or("?");
+            s.push_log(text);
+        }
+    }
+}
+
+// ── Piano drawing ─────────────────────────────────────────────────────────────
+
+fn draw_piano(s: &AppState, x: f32, y: f32, canvas_w: f32) {
+    // Center the keyboard
+    let white_count = count_white_keys(PIANO_START_NOTE, PIANO_END_NOTE);
+    let total_w = white_count as f32 * WHITE_KEY_W;
+    let offset_x = x + ((canvas_w - 32.0 - total_w) * 0.5).max(0.0);
+
+    // White keys first
+    let mut wx = offset_x;
+    let mut note = PIANO_START_NOTE;
+    while note <= PIANO_END_NOTE {
+        if is_white(note) {
+            let active = s.active_notes[note as usize];
+            let (r, g, b) = if active {
+                (100u8, 180u8, 255u8)
+            } else {
+                (230u8, 230u8, 230u8)
+            };
+            canvas_rounded_rect(wx, y, WHITE_KEY_W - 1.0, WHITE_KEY_H, 3.0, r, g, b, 255);
+            wx += WHITE_KEY_W;
+        }
+        note += 1;
+    }
+
+    // Black keys on top
+    wx = offset_x;
+    note = PIANO_START_NOTE;
+    while note <= PIANO_END_NOTE {
+        if is_white(note) {
+            if note < PIANO_END_NOTE && !is_white(note + 1) {
+                // There's a black key after this white key
+                let bx = wx + WHITE_KEY_W - BLACK_KEY_W * 0.5 - 1.0;
+                let black_note = note + 1;
+                let active = s.active_notes[black_note as usize];
+                let (r, g, b) = if active {
+                    (60u8, 140u8, 230u8)
+                } else {
+                    (30u8, 35u8, 50u8)
+                };
+                canvas_rounded_rect(bx, y, BLACK_KEY_W, BLACK_KEY_H, 2.0, r, g, b, 255);
+            }
+            wx += WHITE_KEY_W;
+        }
+        note += 1;
+    }
+
+    // Label: octave markers (C notes)
+    wx = offset_x;
+    note = PIANO_START_NOTE;
+    while note <= PIANO_END_NOTE {
+        if is_white(note) {
+            if note.is_multiple_of(12) {
+                // C note
+                let octave = note / 12 - 1; // MIDI C4 = note 60 = octave 4
+                let label = match octave {
+                    1 => "C1",
+                    2 => "C2",
+                    3 => "C3",
+                    4 => "C4",
+                    5 => "C5",
+                    6 => "C6",
+                    7 => "C7",
+                    _ => "C",
+                };
+                canvas_text(
+                    wx + 2.0,
+                    y + WHITE_KEY_H - 14.0,
+                    10.0,
+                    80,
+                    90,
+                    110,
+                    255,
+                    label,
+                );
+            }
+            wx += WHITE_KEY_W;
+        }
+        note += 1;
+    }
+}
+
+fn is_white(note: u8) -> bool {
+    matches!(note % 12, 0 | 2 | 4 | 5 | 7 | 9 | 11)
+}
+
+fn count_white_keys(start: u8, end: u8) -> u32 {
+    let mut count = 0u32;
+    let mut n = start;
+    while n <= end {
+        if is_white(n) {
+            count += 1;
+        }
+        n += 1;
+    }
+    count
+}
+
+// ── Message formatting (no heap alloc) ───────────────────────────────────────
+
+fn note_name(note: u8) -> &'static str {
+    match note % 12 {
+        0 => "C",
+        1 => "C#",
+        2 => "D",
+        3 => "D#",
+        4 => "E",
+        5 => "F",
+        6 => "F#",
+        7 => "G",
+        8 => "G#",
+        9 => "A",
+        10 => "A#",
+        11 => "B",
+        _ => "?",
+    }
+}
+
+fn format_note_on(ch: u8, note: u8, vel: u8) -> alloc::string::String {
+    let octave = (note / 12) as i32 - 1;
+    alloc::format!(
+        "▶ Note On   ch{:2}  {:3}{:2}  vel={:3}",
+        ch,
+        note_name(note),
+        octave,
+        vel
+    )
+}
+
+fn format_note_off(ch: u8, note: u8) -> alloc::string::String {
+    let octave = (note / 12) as i32 - 1;
+    alloc::format!("■ Note Off  ch{:2}  {:3}{:2}", ch, note_name(note), octave)
+}
+
+fn format_cc(buf: &mut [u8; 48], ch: u8, cc: u8, val: u8) -> &str {
+    let text = alloc::format!("~ CC        ch{:2}  cc={:3}  val={:3}", ch, cc, val);
+    let bytes = text.as_bytes();
+    let n = bytes.len().min(buf.len());
+    buf[..n].copy_from_slice(&bytes[..n]);
+    core::str::from_utf8(&buf[..n]).unwrap_or("")
+}
+
+fn format_prog(buf: &mut [u8; 32], ch: u8, prog: u8) -> &str {
+    let text = alloc::format!("♪ Prog Chg  ch{:2}  prog={:3}", ch, prog);
+    let bytes = text.as_bytes();
+    let n = bytes.len().min(buf.len());
+    buf[..n].copy_from_slice(&bytes[..n]);
+    core::str::from_utf8(&buf[..n]).unwrap_or("")
+}
+
+fn format_pitchbend(buf: &mut [u8; 32], ch: u8, bend: i16) -> &str {
+    let text = alloc::format!("↕ Pitch Bend ch{:2} {:+5}", ch, bend);
+    let bytes = text.as_bytes();
+    let n = bytes.len().min(buf.len());
+    buf[..n].copy_from_slice(&bytes[..n]);
+    core::str::from_utf8(&buf[..n]).unwrap_or("")
+}
+
+fn format_hex(buf: &mut [u8; 48], data: &[u8]) -> usize {
+    let mut pos = 0usize;
+    let prefix = b"? Hex: ";
+    buf[..prefix.len()].copy_from_slice(prefix);
+    pos += prefix.len();
+    for byte in data.iter().take(8) {
+        if pos + 3 > buf.len() {
+            break;
+        }
+        let hi = byte >> 4;
+        let lo = byte & 0xF;
+        buf[pos] = hex_char(hi);
+        buf[pos + 1] = hex_char(lo);
+        buf[pos + 2] = b' ';
+        pos += 3;
+    }
+    pos
+}
+
+fn hex_char(n: u8) -> u8 {
+    if n < 10 {
+        b'0' + n
+    } else {
+        b'a' + n - 10
+    }
+}
+
+fn log_color(text: &str) -> (u8, u8, u8) {
+    if text.starts_with('▶') {
+        (80, 220, 140) // Note On — green
+    } else if text.starts_with('■') {
+        (140, 150, 180) // Note Off — grey
+    } else if text.starts_with('~') {
+        (200, 160, 80) // CC — amber
+    } else if text.starts_with('♪') {
+        (160, 120, 220) // Prog Change — purple
+    } else if text.starts_with('↕') {
+        (100, 180, 220) // Pitch Bend — blue
+    } else if text.starts_with("Connected") {
+        (60, 200, 140) // system
+    } else {
+        (140, 150, 170)
+    }
+}
+
+extern crate alloc;

--- a/examples/raf-demo/src/lib.rs
+++ b/examples/raf-demo/src/lib.rs
@@ -103,6 +103,8 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             status,
         );
 
+        let vx = VX;
+        let vy = VY;
         canvas_text(
             20.0,
             110.0,
@@ -111,7 +113,7 @@ pub extern "C" fn on_frame(_dt_ms: u32) {
             180,
             200,
             255,
-            &format!("pos: ({:.1}, {:.1})  vel: ({:.1}, {:.1})", x, y, VX, VY),
+            &format!("pos: ({:.1}, {:.1})  vel: ({:.1}, {:.1})", x, y, vx, vy),
         );
 
         // Toggle button

--- a/oxide-browser/Cargo.toml
+++ b/oxide-browser/Cargo.toml
@@ -46,5 +46,8 @@ serde_json = "1.0.149"
 futures-util = "0.3"
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+coremidi = "0.7"
+
 [dev-dependencies]
 tempfile = "3"

--- a/oxide-browser/src/bookmarks.rs
+++ b/oxide-browser/src/bookmarks.rs
@@ -156,7 +156,7 @@ impl BookmarkStore {
                 }
             }
         }
-        bookmarks.sort_by(|a, b| b.created_at_ms.cmp(&a.created_at_ms));
+        bookmarks.sort_by_key(|b| std::cmp::Reverse(b.created_at_ms));
         bookmarks
     }
 

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -3433,16 +3433,11 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
             let data = read_guest_bytes(&mem, &caller, data_ptr, data_len).unwrap_or_default();
             let offset = ((offset_hi as u64) << 32) | (offset_lo as u64);
             let gpu_lock = caller.data().gpu.lock().unwrap();
-            match gpu_lock.as_ref() {
-                Some(g) => {
-                    if g.write_buffer(handle, offset, &data) {
-                        1
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            }
+            u32::from(
+                gpu_lock
+                    .as_ref()
+                    .is_some_and(|g| g.write_buffer(handle, offset, &data)),
+            )
         },
     )?;
 
@@ -3456,16 +3451,11 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
          instance_count: u32|
          -> u32 {
             let gpu_lock = caller.data().gpu.lock().unwrap();
-            match gpu_lock.as_ref() {
-                Some(g) => {
-                    if g.draw(pipeline, target, vertex_count, instance_count) {
-                        1
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            }
+            u32::from(
+                gpu_lock
+                    .as_ref()
+                    .is_some_and(|g| g.draw(pipeline, target, vertex_count, instance_count)),
+            )
         },
     )?;
 
@@ -3474,16 +3464,11 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
         "api_gpu_dispatch_compute",
         |caller: Caller<'_, HostState>, pipeline: u32, x: u32, y: u32, z: u32| -> u32 {
             let gpu_lock = caller.data().gpu.lock().unwrap();
-            match gpu_lock.as_ref() {
-                Some(g) => {
-                    if g.dispatch_compute(pipeline, x, y, z) {
-                        1
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            }
+            u32::from(
+                gpu_lock
+                    .as_ref()
+                    .is_some_and(|g| g.dispatch_compute(pipeline, x, y, z)),
+            )
         },
     )?;
 
@@ -3492,16 +3477,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
         "api_gpu_destroy_buffer",
         |caller: Caller<'_, HostState>, handle: u32| -> u32 {
             let mut gpu_lock = caller.data().gpu.lock().unwrap();
-            match gpu_lock.as_mut() {
-                Some(g) => {
-                    if g.destroy_buffer(handle) {
-                        1
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            }
+            u32::from(gpu_lock.as_mut().is_some_and(|g| g.destroy_buffer(handle)))
         },
     )?;
 
@@ -3510,16 +3486,7 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
         "api_gpu_destroy_texture",
         |caller: Caller<'_, HostState>, handle: u32| -> u32 {
             let mut gpu_lock = caller.data().gpu.lock().unwrap();
-            match gpu_lock.as_mut() {
-                Some(g) => {
-                    if g.destroy_texture(handle) {
-                        1
-                    } else {
-                        0
-                    }
-                }
-                None => 0,
-            }
+            u32::from(gpu_lock.as_mut().is_some_and(|g| g.destroy_texture(handle)))
         },
     )?;
 

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -191,6 +191,8 @@ pub struct HostState {
     pub rtc: Arc<Mutex<Option<crate::rtc::RtcState>>>,
     /// WebSocket connections (lazily initialised on first ws call).
     pub ws: Arc<Mutex<Option<crate::websocket::WsState>>>,
+    /// MIDI input/output connections (lazily initialised on first midi_open call).
+    pub midi: Arc<Mutex<Option<crate::midi::MidiState>>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -560,6 +562,7 @@ impl Default for HostState {
             gpu: Arc::new(Mutex::new(None)),
             rtc: Arc::new(Mutex::new(None)),
             ws: Arc::new(Mutex::new(None)),
+            midi: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -3525,6 +3528,9 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
 
     // ── WebSocket API ─────────────────────────────────────────────────
     crate::websocket::register_ws_functions(linker)?;
+
+    // ── MIDI API ──────────────────────────────────────────────────────
+    crate::midi::register_midi_functions(linker)?;
 
     Ok(())
 }

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -102,6 +102,7 @@ pub mod engine;
 pub mod gpu;
 pub mod history;
 pub mod media_capture;
+pub mod midi;
 pub mod navigation;
 pub mod rtc;
 pub mod runtime;

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -48,6 +48,8 @@
 //! | [`gpu`] | WebGPU-style GPU resource management (buffers, textures, shaders, pipelines) |
 //! | [`media_capture`] | Camera, microphone, and screen capture with permission prompts |
 //! | [`rtc`] | WebRTC peer connections, data channels, media tracks, and signaling |
+//! | [`websocket`] | WebSocket client connections (text/binary frames, ready-state polling) |
+//! | [`midi`] | MIDI input/output device enumeration and I/O (CoreMIDI on macOS) |
 //! | [`navigation`] | Browser history stack with back/forward traversal |
 //! | [`bookmarks`] | Persistent bookmark storage backed by sled |
 //! | [`url`] | WHATWG-compliant URL parsing with Oxide-specific schemes |

--- a/oxide-browser/src/midi.rs
+++ b/oxide-browser/src/midi.rs
@@ -394,15 +394,10 @@ pub fn register_midi_functions(linker: &mut Linker<HostState>) -> Result<()> {
             };
             let midi = caller.data().midi.clone();
             let mut g = midi.lock().unwrap();
-            match g.as_mut() {
-                Some(s) => {
-                    if s.send(handle, &data) {
-                        0
-                    } else {
-                        -1
-                    }
-                }
-                None => -1,
+            if g.as_mut().is_some_and(|s| s.send(handle, &data)) {
+                0
+            } else {
+                -1
             }
         },
     )?;

--- a/oxide-browser/src/midi.rs
+++ b/oxide-browser/src/midi.rs
@@ -1,0 +1,387 @@
+//! Host-side MIDI device enumeration and I/O for Oxide guest modules.
+//!
+//! Guests call the `api_midi_*` imports to enumerate MIDI input/output ports,
+//! open connections, send raw MIDI bytes, and poll for incoming messages.
+//!
+//! **macOS**: implemented via CoreMIDI (`coremidi` crate). Input callbacks run
+//! on a CoreMIDI background thread and push messages into a per-handle
+//! [`VecDeque`]. The guest drains the queue by calling `api_midi_recv` each
+//! frame — no blocking, no async runtime needed.
+//!
+//! **Other platforms**: all functions return 0 / error codes gracefully (no
+//! devices found). MIDI support for Linux and Windows will be added in a later
+//! phase.
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use wasmtime::{Caller, Linker};
+
+use crate::capabilities::{read_guest_bytes, write_guest_bytes, HostState};
+
+// ── Platform implementation ───────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Arc, Mutex};
+
+    use coremidi::{Client, Destination, InputPort, OutputPort, PacketList, Source};
+
+    // ── Per-handle state ──────────────────────────────────────────────────
+
+    pub struct InputConn {
+        /// Kept alive — dropping closes the CoreMIDI port.
+        _port: InputPort,
+        pub queue: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    }
+
+    pub struct OutputConn {
+        port: OutputPort,
+        dest_idx: usize,
+    }
+
+    // ── MidiState ─────────────────────────────────────────────────────────
+
+    pub struct MidiState {
+        client: Client,
+        next_handle: u32,
+        inputs: HashMap<u32, InputConn>,
+        outputs: HashMap<u32, OutputConn>,
+    }
+
+    impl MidiState {
+        pub fn new() -> Option<Self> {
+            let client = Client::new("oxide-browser").ok()?;
+            Some(Self {
+                client,
+                next_handle: 1,
+                inputs: HashMap::new(),
+                outputs: HashMap::new(),
+            })
+        }
+
+        fn alloc_handle(&mut self) -> u32 {
+            let h = self.next_handle;
+            self.next_handle = self.next_handle.wrapping_add(1).max(1);
+            h
+        }
+
+        pub fn input_count() -> u32 {
+            coremidi::Sources::count() as u32
+        }
+
+        pub fn output_count() -> u32 {
+            coremidi::Destinations::count() as u32
+        }
+
+        pub fn input_name(index: u32) -> Option<String> {
+            let src = Source::from_index(index as usize)?;
+            src.display_name()
+                .or_else(|| Some(format!("Input {}", index)))
+        }
+
+        pub fn output_name(index: u32) -> Option<String> {
+            let dst = Destination::from_index(index as usize)?;
+            dst.display_name()
+                .or_else(|| Some(format!("Output {}", index)))
+        }
+
+        pub fn open_input(&mut self, index: u32) -> u32 {
+            let source = match Source::from_index(index as usize) {
+                Some(s) => s,
+                None => return 0,
+            };
+            let queue: Arc<Mutex<VecDeque<Vec<u8>>>> = Arc::new(Mutex::new(VecDeque::new()));
+            let q = queue.clone();
+            let port_name = format!("oxide-in-{}", index);
+            let port = match self
+                .client
+                .input_port(&port_name, move |pkt_list: &PacketList| {
+                    let mut lock = q.lock().unwrap();
+                    for pkt in pkt_list.iter() {
+                        if !pkt.data().is_empty() {
+                            lock.push_back(pkt.data().to_vec());
+                        }
+                    }
+                }) {
+                Ok(p) => p,
+                Err(_) => return 0,
+            };
+            if port.connect_source(&source).is_err() {
+                return 0;
+            }
+            let handle = self.alloc_handle();
+            self.inputs.insert(handle, InputConn { _port: port, queue });
+            handle
+        }
+
+        pub fn open_output(&mut self, index: u32) -> u32 {
+            let port_name = format!("oxide-out-{}", index);
+            let port = match self.client.output_port(&port_name) {
+                Ok(p) => p,
+                Err(_) => return 0,
+            };
+            let handle = self.alloc_handle();
+            self.outputs.insert(
+                handle,
+                OutputConn {
+                    port,
+                    dest_idx: index as usize,
+                },
+            );
+            handle
+        }
+
+        pub fn send(&mut self, handle: u32, data: &[u8]) -> bool {
+            let out = match self.outputs.get_mut(&handle) {
+                Some(o) => o,
+                None => return false,
+            };
+            let dest = match Destination::from_index(out.dest_idx) {
+                Some(d) => d,
+                None => return false,
+            };
+            // Build a single-packet PacketList from raw bytes.
+            let packets = coremidi::PacketBuffer::new(0, data);
+            out.port.send(&dest, &packets).is_ok()
+        }
+
+        pub fn recv(&self, handle: u32) -> Option<Vec<u8>> {
+            self.inputs.get(&handle)?.queue.lock().unwrap().pop_front()
+        }
+
+        pub fn close(&mut self, handle: u32) {
+            self.inputs.remove(&handle);
+            self.outputs.remove(&handle);
+        }
+    }
+}
+
+// ── Stub for non-macOS ────────────────────────────────────────────────────────
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    /// Placeholder — MIDI is not yet supported on this platform.
+    pub struct MidiState;
+
+    impl MidiState {
+        pub fn new() -> Option<Self> {
+            Some(Self)
+        }
+        pub fn input_count() -> u32 {
+            0
+        }
+        pub fn output_count() -> u32 {
+            0
+        }
+        pub fn input_name(_index: u32) -> Option<String> {
+            None
+        }
+        pub fn output_name(_index: u32) -> Option<String> {
+            None
+        }
+        pub fn open_input(&mut self, _index: u32) -> u32 {
+            0
+        }
+        pub fn open_output(&mut self, _index: u32) -> u32 {
+            0
+        }
+        pub fn send(&mut self, _handle: u32, _data: &[u8]) -> bool {
+            false
+        }
+        pub fn recv(&self, _handle: u32) -> Option<Vec<u8>> {
+            None
+        }
+        pub fn close(&mut self, _handle: u32) {}
+    }
+}
+
+// ── Public re-export ──────────────────────────────────────────────────────────
+
+pub use platform::MidiState;
+
+// ── Lazy initialisation helper ────────────────────────────────────────────────
+
+fn ensure_midi(state: &Arc<Mutex<Option<MidiState>>>) {
+    let mut g = state.lock().unwrap();
+    if g.is_none() {
+        *g = MidiState::new();
+    }
+}
+
+// ── Host function registration ────────────────────────────────────────────────
+
+/// Register all `api_midi_*` host functions on the given linker.
+pub fn register_midi_functions(linker: &mut Linker<HostState>) -> Result<()> {
+    // ── midi_input_count ──────────────────────────────────────────────────
+    // api_midi_input_count() -> u32
+    linker.func_wrap(
+        "oxide",
+        "api_midi_input_count",
+        |_caller: Caller<'_, HostState>| -> u32 { MidiState::input_count() },
+    )?;
+
+    // ── midi_output_count ─────────────────────────────────────────────────
+    // api_midi_output_count() -> u32
+    linker.func_wrap(
+        "oxide",
+        "api_midi_output_count",
+        |_caller: Caller<'_, HostState>| -> u32 { MidiState::output_count() },
+    )?;
+
+    // ── midi_input_name ───────────────────────────────────────────────────
+    // api_midi_input_name(index: u32, out_ptr: u32, out_cap: u32) -> u32
+    // Writes the port name into guest memory. Returns bytes written, or 0
+    // if the index is out of range.
+    linker.func_wrap(
+        "oxide",
+        "api_midi_input_name",
+        |mut caller: Caller<'_, HostState>, index: u32, out_ptr: u32, out_cap: u32| -> u32 {
+            let name = match MidiState::input_name(index) {
+                Some(n) => n,
+                None => return 0,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let bytes = name.as_bytes();
+            let len = bytes.len().min(out_cap as usize);
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &bytes[..len]).is_err() {
+                return 0;
+            }
+            len as u32
+        },
+    )?;
+
+    // ── midi_output_name ──────────────────────────────────────────────────
+    // api_midi_output_name(index: u32, out_ptr: u32, out_cap: u32) -> u32
+    linker.func_wrap(
+        "oxide",
+        "api_midi_output_name",
+        |mut caller: Caller<'_, HostState>, index: u32, out_ptr: u32, out_cap: u32| -> u32 {
+            let name = match MidiState::output_name(index) {
+                Some(n) => n,
+                None => return 0,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let bytes = name.as_bytes();
+            let len = bytes.len().min(out_cap as usize);
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &bytes[..len]).is_err() {
+                return 0;
+            }
+            len as u32
+        },
+    )?;
+
+    // ── midi_open_input ───────────────────────────────────────────────────
+    // api_midi_open_input(index: u32) -> u32
+    // Returns a handle (> 0) or 0 on failure.
+    linker.func_wrap(
+        "oxide",
+        "api_midi_open_input",
+        |caller: Caller<'_, HostState>, index: u32| -> u32 {
+            let midi = caller.data().midi.clone();
+            ensure_midi(&midi);
+            let mut g = midi.lock().unwrap();
+            g.as_mut().map(|s| s.open_input(index)).unwrap_or(0)
+        },
+    )?;
+
+    // ── midi_open_output ──────────────────────────────────────────────────
+    // api_midi_open_output(index: u32) -> u32
+    linker.func_wrap(
+        "oxide",
+        "api_midi_open_output",
+        |caller: Caller<'_, HostState>, index: u32| -> u32 {
+            let midi = caller.data().midi.clone();
+            ensure_midi(&midi);
+            let mut g = midi.lock().unwrap();
+            g.as_mut().map(|s| s.open_output(index)).unwrap_or(0)
+        },
+    )?;
+
+    // ── midi_send ─────────────────────────────────────────────────────────
+    // api_midi_send(handle: u32, data_ptr: u32, data_len: u32) -> i32
+    // Returns 0 on success, -1 on failure.
+    linker.func_wrap(
+        "oxide",
+        "api_midi_send",
+        |caller: Caller<'_, HostState>, handle: u32, ptr: u32, len: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let data = match read_guest_bytes(&mem, &caller, ptr, len) {
+                Ok(b) => b,
+                Err(_) => return -1,
+            };
+            let midi = caller.data().midi.clone();
+            let mut g = midi.lock().unwrap();
+            match g.as_mut() {
+                Some(s) => {
+                    if s.send(handle, &data) {
+                        0
+                    } else {
+                        -1
+                    }
+                }
+                None => -1,
+            }
+        },
+    )?;
+
+    // ── midi_recv ─────────────────────────────────────────────────────────
+    // api_midi_recv(handle: u32, out_ptr: u32, out_cap: u32) -> i32
+    // Dequeues one MIDI message and writes its bytes into guest memory.
+    // Returns bytes written, or -1 if the queue is empty.
+    linker.func_wrap(
+        "oxide",
+        "api_midi_recv",
+        |mut caller: Caller<'_, HostState>, handle: u32, out_ptr: u32, out_cap: u32| -> i32 {
+            let midi = caller.data().midi.clone();
+            let msg = {
+                let g = midi.lock().unwrap();
+                g.as_ref().and_then(|s| s.recv(handle))
+            };
+            let msg = match msg {
+                Some(m) => m,
+                None => return -1,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let to_write = if msg.len() > out_cap as usize {
+                &msg[..out_cap as usize]
+            } else {
+                &msg
+            };
+            if write_guest_bytes(&mem, &mut caller, out_ptr, to_write).is_err() {
+                return -1;
+            }
+            to_write.len() as i32
+        },
+    )?;
+
+    // ── midi_close ────────────────────────────────────────────────────────
+    // api_midi_close(handle: u32)
+    // Frees host-side resources for the given handle.
+    linker.func_wrap(
+        "oxide",
+        "api_midi_close",
+        |caller: Caller<'_, HostState>, handle: u32| {
+            let midi = caller.data().midi.clone();
+            let mut g = midi.lock().unwrap();
+            if let Some(ref mut state) = *g {
+                state.close(handle);
+            }
+        },
+    )?;
+
+    Ok(())
+}

--- a/oxide-browser/src/midi.rs
+++ b/oxide-browser/src/midi.rs
@@ -4,9 +4,11 @@
 //! open connections, send raw MIDI bytes, and poll for incoming messages.
 //!
 //! **macOS**: implemented via CoreMIDI (`coremidi` crate). Input callbacks run
-//! on a CoreMIDI background thread and push messages into a per-handle
-//! [`VecDeque`]. The guest drains the queue by calling `api_midi_recv` each
-//! frame — no blocking, no async runtime needed.
+//! on a CoreMIDI background thread, split each incoming packet into individual
+//! MIDI messages, and push them onto a per-handle bounded [`VecDeque`]. The
+//! guest drains the queue by calling `api_midi_recv` each frame — no blocking,
+//! no async runtime needed. Each `api_midi_recv` returns exactly one MIDI
+//! message; if the queue fills up, the oldest message is dropped.
 //!
 //! **Other platforms**: all functions return 0 / error codes gracefully (no
 //! devices found). MIDI support for Linux and Windows will be added in a later
@@ -27,6 +29,59 @@ mod platform {
     use std::sync::{Arc, Mutex};
 
     use coremidi::{Client, Destination, InputPort, OutputPort, PacketList, Source};
+
+    /// Hard cap on queued incoming MIDI messages per input port. If the guest
+    /// falls behind, oldest messages are dropped first. 4096 is ~1 MB worst
+    /// case with 256-byte SysEx dumps; for typical 3-byte note events it's
+    /// ~12 KB — plenty for a ~1 min backlog at max MIDI rate (~30k msg/s).
+    const MAX_QUEUED_MESSAGES: usize = 4096;
+
+    /// Split a raw CoreMIDI packet (which may concatenate several MIDI messages
+    /// sharing a timestamp) into individual messages and push each onto `out`,
+    /// enforcing [`MAX_QUEUED_MESSAGES`] by dropping the oldest on overflow.
+    ///
+    /// Handles channel voice (0x80–0xEF), System Common (0xF1–0xF6),
+    /// System Real-Time (0xF8–0xFF), and SysEx (0xF0 … 0xF7). Bytes that
+    /// appear without a preceding status byte (running status, or junk) are
+    /// skipped.
+    fn enqueue_messages(data: &[u8], out: &mut VecDeque<Vec<u8>>) {
+        let mut i = 0;
+        while i < data.len() {
+            let status = data[i];
+            if status & 0x80 == 0 {
+                // Data byte with no status — skip. CoreMIDI normally delivers
+                // complete messages, so this only hits on malformed input.
+                i += 1;
+                continue;
+            }
+            let end = match status & 0xF0 {
+                0x80 | 0x90 | 0xA0 | 0xB0 | 0xE0 => i + 3,
+                0xC0 | 0xD0 => i + 2,
+                0xF0 => match status {
+                    0xF0 => {
+                        // SysEx: consume up to and including the next 0xF7.
+                        match data[i + 1..].iter().position(|&b| b == 0xF7) {
+                            Some(p) => i + 1 + p + 1,
+                            None => data.len(),
+                        }
+                    }
+                    0xF1 | 0xF3 => i + 2,
+                    0xF2 => i + 3,
+                    // 0xF4–0xF7 (undefined / SysEx end) and 0xF8–0xFF
+                    // (real-time) are single-byte messages.
+                    _ => i + 1,
+                },
+                _ => i + 1,
+            };
+            let end = end.min(data.len());
+            let msg: Vec<u8> = data[i..end].to_vec();
+            if out.len() >= MAX_QUEUED_MESSAGES {
+                out.pop_front();
+            }
+            out.push_back(msg);
+            i = end;
+        }
+    }
 
     // ── Per-handle state ──────────────────────────────────────────────────
 
@@ -100,8 +155,9 @@ mod platform {
                 .input_port(&port_name, move |pkt_list: &PacketList| {
                     let mut lock = q.lock().unwrap();
                     for pkt in pkt_list.iter() {
-                        if !pkt.data().is_empty() {
-                            lock.push_back(pkt.data().to_vec());
+                        let bytes = pkt.data();
+                        if !bytes.is_empty() {
+                            enqueue_messages(bytes, &mut lock);
                         }
                     }
                 }) {
@@ -147,6 +203,19 @@ mod platform {
             out.port.send(&dest, &packets).is_ok()
         }
 
+        /// Length in bytes of the front queued message without popping it.
+        /// Used by `api_midi_recv` to decide whether the guest's buffer is
+        /// large enough before dequeuing.
+        pub fn peek_len(&self, handle: u32) -> Option<usize> {
+            self.inputs
+                .get(&handle)?
+                .queue
+                .lock()
+                .unwrap()
+                .front()
+                .map(|m| m.len())
+        }
+
         pub fn recv(&self, handle: u32) -> Option<Vec<u8>> {
             self.inputs.get(&handle)?.queue.lock().unwrap().pop_front()
         }
@@ -189,6 +258,9 @@ mod platform {
         }
         pub fn send(&mut self, _handle: u32, _data: &[u8]) -> bool {
             false
+        }
+        pub fn peek_len(&self, _handle: u32) -> Option<usize> {
+            None
         }
         pub fn recv(&self, _handle: u32) -> Option<Vec<u8>> {
             None
@@ -338,33 +410,40 @@ pub fn register_midi_functions(linker: &mut Linker<HostState>) -> Result<()> {
     // ── midi_recv ─────────────────────────────────────────────────────────
     // api_midi_recv(handle: u32, out_ptr: u32, out_cap: u32) -> i32
     // Dequeues one MIDI message and writes its bytes into guest memory.
-    // Returns bytes written, or -1 if the queue is empty.
+    // Returns bytes written on success, -1 if the queue is empty, or -2 if
+    // the guest buffer is too small (message stays in the queue so the guest
+    // can retry with a larger buffer).
     linker.func_wrap(
         "oxide",
         "api_midi_recv",
         |mut caller: Caller<'_, HostState>, handle: u32, out_ptr: u32, out_cap: u32| -> i32 {
             let midi = caller.data().midi.clone();
+            let peek = {
+                let g = midi.lock().unwrap();
+                g.as_ref().and_then(|s| s.peek_len(handle))
+            };
+            let msg_len = match peek {
+                Some(n) => n,
+                None => return -1,
+            };
+            if msg_len > out_cap as usize {
+                return -2;
+            }
             let msg = {
                 let g = midi.lock().unwrap();
-                g.as_ref().and_then(|s| s.recv(handle))
-            };
-            let msg = match msg {
-                Some(m) => m,
-                None => return -1,
+                match g.as_ref().and_then(|s| s.recv(handle)) {
+                    Some(m) => m,
+                    None => return -1,
+                }
             };
             let mem = match caller.data().memory {
                 Some(m) => m,
                 None => return -1,
             };
-            let to_write = if msg.len() > out_cap as usize {
-                &msg[..out_cap as usize]
-            } else {
-                &msg
-            };
-            if write_guest_bytes(&mem, &mut caller, out_ptr, to_write).is_err() {
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &msg).is_err() {
                 return -1;
             }
-            to_write.len() as i32
+            msg.len() as i32
         },
     )?;
 

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -756,6 +756,35 @@ extern "C" {
     #[link_name = "api_ws_remove"]
     fn _api_ws_remove(id: u32);
 
+    // ── MIDI API ────────────────────────────────────────────────────
+
+    #[link_name = "api_midi_input_count"]
+    fn _api_midi_input_count() -> u32;
+
+    #[link_name = "api_midi_output_count"]
+    fn _api_midi_output_count() -> u32;
+
+    #[link_name = "api_midi_input_name"]
+    fn _api_midi_input_name(index: u32, out_ptr: u32, out_cap: u32) -> u32;
+
+    #[link_name = "api_midi_output_name"]
+    fn _api_midi_output_name(index: u32, out_ptr: u32, out_cap: u32) -> u32;
+
+    #[link_name = "api_midi_open_input"]
+    fn _api_midi_open_input(index: u32) -> u32;
+
+    #[link_name = "api_midi_open_output"]
+    fn _api_midi_open_output(index: u32) -> u32;
+
+    #[link_name = "api_midi_send"]
+    fn _api_midi_send(handle: u32, data_ptr: u32, data_len: u32) -> i32;
+
+    #[link_name = "api_midi_recv"]
+    fn _api_midi_recv(handle: u32, out_ptr: u32, out_cap: u32) -> i32;
+
+    #[link_name = "api_midi_close"]
+    fn _api_midi_close(handle: u32);
+
     // ── URL Utilities ───────────────────────────────────────────────
 
     #[link_name = "api_url_resolve"]
@@ -2026,6 +2055,77 @@ pub fn ws_close(id: u32) -> i32 {
 /// leaks.
 pub fn ws_remove(id: u32) {
     unsafe { _api_ws_remove(id) }
+}
+
+// ─── MIDI API ────────────────────────────────────────────────────────────────
+
+/// Number of available MIDI input ports (physical and virtual).
+pub fn midi_input_count() -> u32 {
+    unsafe { _api_midi_input_count() }
+}
+
+/// Number of available MIDI output ports.
+pub fn midi_output_count() -> u32 {
+    unsafe { _api_midi_output_count() }
+}
+
+/// Name of the MIDI input port at `index`.
+///
+/// Returns an empty string if the index is out of range.
+pub fn midi_input_name(index: u32) -> String {
+    let mut buf = [0u8; 128];
+    let len = unsafe { _api_midi_input_name(index, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    String::from_utf8_lossy(&buf[..len as usize]).to_string()
+}
+
+/// Name of the MIDI output port at `index`.
+///
+/// Returns an empty string if the index is out of range.
+pub fn midi_output_name(index: u32) -> String {
+    let mut buf = [0u8; 128];
+    let len = unsafe { _api_midi_output_name(index, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    String::from_utf8_lossy(&buf[..len as usize]).to_string()
+}
+
+/// Open a MIDI input port by index and start receiving messages.
+///
+/// Returns a handle (`> 0`) on success, or `0` if the port could not be opened.
+/// Incoming messages are queued internally; drain them with [`midi_recv`].
+pub fn midi_open_input(index: u32) -> u32 {
+    unsafe { _api_midi_open_input(index) }
+}
+
+/// Open a MIDI output port by index for sending messages.
+///
+/// Returns a handle (`> 0`) on success, or `0` on failure.
+pub fn midi_open_output(index: u32) -> u32 {
+    unsafe { _api_midi_open_output(index) }
+}
+
+/// Send raw MIDI bytes on an output `handle`.
+///
+/// Returns `0` on success, `-1` if the handle is unknown or the send failed.
+pub fn midi_send(handle: u32, data: &[u8]) -> i32 {
+    unsafe { _api_midi_send(handle, data.as_ptr() as u32, data.len() as u32) }
+}
+
+/// Poll for the next queued MIDI message on an input `handle`.
+///
+/// Returns `Some(bytes)` if a message is available, or `None` if the queue
+/// is empty. MIDI messages are typically 1–3 bytes; SysEx can be longer.
+pub fn midi_recv(handle: u32) -> Option<Vec<u8>> {
+    let mut buf = [0u8; 256];
+    let n = unsafe { _api_midi_recv(handle, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    if n < 0 {
+        None
+    } else {
+        Some(buf[..n as usize].to_vec())
+    }
+}
+
+/// Close a MIDI input or output handle and free host-side resources.
+pub fn midi_close(handle: u32) {
+    unsafe { _api_midi_close(handle) }
 }
 
 // ─── HTTP Fetch API ─────────────────────────────────────────────────────────

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -97,6 +97,7 @@
 //! | **Media capture** | [`camera_open`], [`camera_capture_frame`], [`microphone_open`], [`microphone_read_samples`], [`screen_capture`] |
 //! | **WebRTC** | [`rtc_create_peer`], [`rtc_create_offer`], [`rtc_create_answer`], [`rtc_create_data_channel`], [`rtc_send`], [`rtc_recv`], [`rtc_signal_connect`] |
 //! | **WebSocket** | [`ws_connect`], [`ws_send_text`], [`ws_send_binary`], [`ws_recv`], [`ws_ready_state`], [`ws_close`], [`ws_remove`] |
+//! | **MIDI** | [`midi_input_count`], [`midi_output_count`], [`midi_input_name`], [`midi_output_name`], [`midi_open_input`], [`midi_open_output`], [`midi_send`], [`midi_recv`], [`midi_close`] |
 //! | **Timers** | [`set_timeout`], [`set_interval`], [`clear_timer`], [`request_animation_frame`], [`cancel_animation_frame`], [`time_now_ms`] |
 //! | **Navigation** | [`navigate`], [`push_state`], [`replace_state`], [`get_url`], [`history_back`], [`history_forward`] |
 //! | **Input** | [`mouse_position`], [`mouse_button_down`], [`mouse_button_clicked`], [`key_down`], [`key_pressed`], [`scroll_delta`], [`modifiers`] |
@@ -2111,16 +2112,26 @@ pub fn midi_send(handle: u32, data: &[u8]) -> i32 {
 
 /// Poll for the next queued MIDI message on an input `handle`.
 ///
-/// Returns `Some(bytes)` if a message is available, or `None` if the queue
-/// is empty. MIDI messages are typically 1–3 bytes; SysEx can be longer.
+/// Returns `Some(bytes)` with exactly one MIDI message if one is available,
+/// or `None` if the queue is empty. Channel-voice messages are 2–3 bytes;
+/// SysEx can be longer. The wrapper first tries a 256-byte stack buffer and
+/// transparently retries with a 64 KB heap buffer for large SysEx dumps.
 pub fn midi_recv(handle: u32) -> Option<Vec<u8>> {
     let mut buf = [0u8; 256];
     let n = unsafe { _api_midi_recv(handle, buf.as_mut_ptr() as u32, buf.len() as u32) };
-    if n < 0 {
-        None
-    } else {
-        Some(buf[..n as usize].to_vec())
+    if n >= 0 {
+        return Some(buf[..n as usize].to_vec());
     }
+    // -2 = buffer too small; message is still queued. Retry with 64 KB heap buffer.
+    if n == -2 {
+        let mut big = vec![0u8; 64 * 1024];
+        let n2 = unsafe { _api_midi_recv(handle, big.as_mut_ptr() as u32, big.len() as u32) };
+        if n2 >= 0 {
+            big.truncate(n2 as usize);
+            return Some(big);
+        }
+    }
+    None
 }
 
 /// Close a MIDI input or output handle and free host-side resources.


### PR DESCRIPTION
Adds full MIDI input/output support to Oxide via a new `midi` host module.

## Host (oxide-browser)

- `oxide-browser/src/midi.rs` — new module with platform-conditional implementation:
  - **macOS**: CoreMIDI backend via `coremidi` crate. `open_input` connects a CoreMIDI source; incoming packets are pushed into a per-handle `Arc<Mutex<VecDeque<Vec<u8>>>>` by a CoreMIDI background callback. `open_output` opens a CoreMIDI destination port for sending raw bytes.
  - **Linux / Windows**: no-op stubs returning 0 devices — graceful degradation; cross-platform backends (ALSA, WinMM) can be added later without changing the API.
- `HostState` gains a `midi: Arc<Mutex<Option<MidiState>>>` field, lazily initialised on the first `api_midi_open_*` call.
- 8 host functions registered in `register_midi_functions` (called from `register_host_functions` alongside WebRTC and WebSocket): `api_midi_input_count`, `api_midi_output_count`, `api_midi_input_name`, `api_midi_output_name`, `api_midi_open_input`, `api_midi_open_output`, `api_midi_send`, `api_midi_recv`, `api_midi_close`
- `coremidi = "0.7"` added as a macOS-only target dependency; avoids the `alsa-sys` links conflict that `midir v0.10` would cause with `cpal`.

## SDK (oxide-sdk)

- 9 FFI imports + public wrappers added after the WebSocket section: `midi_input_count`, `midi_output_count`, `midi_input_name`, `midi_output_name`, `midi_open_input`, `midi_open_output`, `midi_send`, `midi_recv` (returns `Option<Vec<u8>>`), `midi_close`.

## Example (examples/midi-demo)

Piano keyboard visualizer guest app demonstrating the full MIDI API:
- Scans input devices once in `start_app`; shows a button per device.
- Click to connect / click again to disconnect.
- Real-time message log (ring buffer, 16 entries) with colour-coded entries: Note On (green), Note Off (grey), CC (amber), Pitch Bend (blue), Program Change (purple), unknown (hex dump).
- Piano keyboard rendering (C2–B5, 4 octaves): white keys light up blue on Note On, black keys light up on their respective notes; keys dim on Note Off. Octave labels drawn on C notes.
- No heap allocations in the hot receive path — incoming bytes are copied to a fixed-size stack array before being dispatched to `handle_midi_message`.

## Other

- Fix pre-existing `static-mut-refs` clippy error in `examples/raf-demo` (read `VX`/`VY` into locals before passing to `format!`).
- `examples/midi-demo` added to workspace members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive MIDI support: host MIDI API, SDK wrappers for enumerate/open/send/receive/close, and crate-level docs.
  * Added a new MIDI demo with real-time device monitoring, interactive piano keyboard visualization, message log, and device connect controls.
  * Included the MIDI demo in the workspace.

* **Bug Fixes**
  * Fixed velocity handling in the RAF demo rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->