### PR TITLE
feat(fetch): streaming / non-blocking HTTP fetch API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ members = [
     "examples/rtc-chat",
     "examples/ws-chat",
     "examples/midi-demo",
+    "examples/stream-fetch-demo",
 ]
 resolver = "2"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -255,8 +255,8 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 
 ### Async I/O
 
-- [ ] Non-blocking fetch with callback/promise-style API
-- [ ] Streaming response bodies (chunked transfer)
+- [x] Non-blocking fetch with callback/promise-style API (poll-based via `fetch_begin` / `fetch_state` / `fetch_recv`)
+- [x] Streaming response bodies (chunked transfer) via `fetch_recv`
 - [x] WebSocket support: `ws_connect(url)`, `ws_send_text()`, `ws_send_binary()`, `ws_recv()`, `ws_ready_state()`, `ws_close()`
 - [ ] Server-sent events (SSE) for push updates
 

--- a/examples/stream-fetch-demo/Cargo.toml
+++ b/examples/stream-fetch-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "stream-fetch-demo"
+version = "0.1.0"
+edition = "2021"
+description = "Streaming / non-blocking fetch demo for the Oxide browser"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/stream-fetch-demo/src/lib.rs
+++ b/examples/stream-fetch-demo/src/lib.rs
@@ -1,0 +1,316 @@
+//! Streaming fetch demo.
+//!
+//! Demonstrates the non-blocking fetch API: dispatch a request with
+//! `fetch_begin`, keep rendering, and drain body chunks with `fetch_recv` as
+//! they arrive. The default URL uses `httpbin.org/drip`, which trickles a
+//! configurable number of bytes over several seconds — perfect for watching
+//! the byte counter tick up while the frame loop keeps running.
+//!
+//! # Building
+//!
+//! ```bash
+//! cargo build --target wasm32-unknown-unknown --release -p stream-fetch-demo
+//! ```
+
+use oxide_sdk::*;
+
+const DEFAULT_URL: &str = "https://httpbin.org/drip?duration=5&numbytes=400&delay=0";
+const BODY_BUF: usize = 8 * 1024;
+const URL_BUF: usize = 512;
+
+static mut STATE: AppState = AppState::new();
+
+struct AppState {
+    handle: u32,
+    bytes: usize,
+    chunks: u32,
+    body: [u8; BODY_BUF],
+    body_len: usize,
+    body_truncated: bool,
+    status: u32,
+    url_buf: [u8; URL_BUF],
+    url_len: usize,
+    last_error: [u8; 256],
+    last_error_len: usize,
+}
+
+impl AppState {
+    const fn new() -> Self {
+        let mut url_buf = [0u8; URL_BUF];
+        let src = DEFAULT_URL.as_bytes();
+        let mut i = 0;
+        while i < src.len() {
+            url_buf[i] = src[i];
+            i += 1;
+        }
+        Self {
+            handle: 0,
+            bytes: 0,
+            chunks: 0,
+            body: [0u8; BODY_BUF],
+            body_len: 0,
+            body_truncated: false,
+            status: 0,
+            url_buf,
+            url_len: DEFAULT_URL.len(),
+            last_error: [0u8; 256],
+            last_error_len: 0,
+        }
+    }
+
+    fn url(&self) -> &str {
+        core::str::from_utf8(&self.url_buf[..self.url_len]).unwrap_or("")
+    }
+
+    fn reset(&mut self) {
+        self.handle = 0;
+        self.bytes = 0;
+        self.chunks = 0;
+        self.body_len = 0;
+        self.body_truncated = false;
+        self.status = 0;
+        self.last_error_len = 0;
+    }
+
+    fn append_body(&mut self, data: &[u8]) {
+        let room = BODY_BUF - self.body_len;
+        if room == 0 {
+            self.body_truncated = true;
+            return;
+        }
+        let take = data.len().min(room);
+        self.body[self.body_len..self.body_len + take].copy_from_slice(&data[..take]);
+        self.body_len += take;
+        if take < data.len() {
+            self.body_truncated = true;
+        }
+    }
+
+    fn set_error(&mut self, msg: &str) {
+        let bytes = msg.as_bytes();
+        let n = bytes.len().min(self.last_error.len());
+        self.last_error[..n].copy_from_slice(&bytes[..n]);
+        self.last_error_len = n;
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("Streaming fetch demo loaded");
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let s = unsafe { &mut *core::ptr::addr_of_mut!(STATE) };
+    let (w, h) = canvas_dimensions();
+    let w = w as f32;
+    let h = h as f32;
+
+    canvas_clear(20, 24, 36, 255);
+
+    // ── Header ────────────────────────────────────────────────────────────
+    canvas_rect(0.0, 0.0, w, 48.0, 28, 34, 54, 255);
+    canvas_text(
+        14.0,
+        14.0,
+        20.0,
+        160,
+        200,
+        255,
+        255,
+        "Oxide Streaming Fetch",
+    );
+
+    // ── State badge ───────────────────────────────────────────────────────
+    let (br, bg, bb, label) = if s.handle == 0 {
+        (100, 100, 120, "IDLE")
+    } else {
+        match fetch_state(s.handle) {
+            FETCH_PENDING => (200, 160, 0, "PENDING"),
+            FETCH_STREAMING => (40, 200, 100, "STREAMING"),
+            FETCH_DONE => (80, 140, 255, "DONE"),
+            FETCH_ERROR => (220, 80, 80, "ERROR"),
+            FETCH_ABORTED => (200, 120, 0, "ABORTED"),
+            _ => (140, 140, 160, "?"),
+        }
+    };
+    canvas_rounded_rect(w - 140.0, 12.0, 128.0, 24.0, 12.0, br, bg, bb, 60);
+    canvas_text(w - 132.0, 17.0, 13.0, br, bg, bb, 255, label);
+
+    // ── URL row ───────────────────────────────────────────────────────────
+    let row_y = 60.0;
+    canvas_text(14.0, row_y + 4.0, 13.0, 140, 150, 180, 255, "URL:");
+    let url_val = ui_text_input(1, 60.0, row_y, w - 290.0, s.url());
+    {
+        let bytes = url_val.as_bytes();
+        let n = bytes.len().min(URL_BUF - 1);
+        s.url_buf[..n].copy_from_slice(&bytes[..n]);
+        s.url_len = n;
+    }
+
+    let btn_x = w - 220.0;
+    let active = s.handle != 0 && matches!(fetch_state(s.handle), FETCH_PENDING | FETCH_STREAMING,);
+
+    if ui_button(
+        2,
+        btn_x,
+        row_y,
+        96.0,
+        28.0,
+        if active { "Restart" } else { "Fetch" },
+    ) {
+        if s.handle != 0 {
+            fetch_abort(s.handle);
+            fetch_remove(s.handle);
+        }
+        s.reset();
+        let url_owned = {
+            let mut tmp = [0u8; URL_BUF];
+            tmp[..s.url_len].copy_from_slice(&s.url_buf[..s.url_len]);
+            (tmp, s.url_len)
+        };
+        let url_str = core::str::from_utf8(&url_owned.0[..url_owned.1]).unwrap_or("");
+        let id = fetch_begin_get(url_str);
+        if id > 0 {
+            s.handle = id;
+        } else {
+            s.set_error("failed to init fetch subsystem");
+        }
+    }
+
+    let abort_x = w - 114.0;
+    if active && ui_button(3, abort_x, row_y, 96.0, 28.0, "Abort") {
+        fetch_abort(s.handle);
+    }
+
+    // ── Drain incoming chunks ─────────────────────────────────────────────
+    if s.handle != 0 {
+        s.status = fetch_status(s.handle);
+        // Drain everything the host has queued this frame; stop on pending/end/error.
+        for _ in 0..64 {
+            match fetch_recv(s.handle) {
+                FetchChunk::Data(bytes) => {
+                    s.chunks += 1;
+                    s.bytes += bytes.len();
+                    s.append_body(&bytes);
+                }
+                FetchChunk::Pending => break,
+                FetchChunk::End => {
+                    log("[stream-fetch] EOF");
+                    break;
+                }
+                FetchChunk::Error => {
+                    if let Some(msg) = fetch_error(s.handle) {
+                        s.set_error(&msg);
+                    } else {
+                        s.set_error("unknown error");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    // ── Stats block ───────────────────────────────────────────────────────
+    let stats_y = 110.0;
+    canvas_rounded_rect(10.0, stats_y, w - 20.0, 84.0, 6.0, 14, 20, 35, 255);
+
+    let mut line = [0u8; 128];
+    let status_text = format_u32(&mut line, s.status);
+    canvas_text(
+        24.0,
+        stats_y + 12.0,
+        14.0,
+        140,
+        150,
+        180,
+        255,
+        "HTTP status:",
+    );
+    canvas_text(130.0, stats_y + 12.0, 14.0, 230, 230, 240, 255, status_text);
+
+    let bytes_text = format_usize(&mut line, s.bytes);
+    canvas_text(
+        24.0,
+        stats_y + 34.0,
+        14.0,
+        140,
+        150,
+        180,
+        255,
+        "Bytes received:",
+    );
+    canvas_text(150.0, stats_y + 34.0, 14.0, 230, 230, 240, 255, bytes_text);
+
+    let chunks_text = format_u32(&mut line, s.chunks);
+    canvas_text(24.0, stats_y + 56.0, 14.0, 140, 150, 180, 255, "Chunks:");
+    canvas_text(90.0, stats_y + 56.0, 14.0, 230, 230, 240, 255, chunks_text);
+
+    // ── Body preview ──────────────────────────────────────────────────────
+    let body_top = stats_y + 100.0;
+    let body_h = h - body_top - 20.0;
+    canvas_rounded_rect(10.0, body_top, w - 20.0, body_h, 6.0, 12, 16, 28, 255);
+    canvas_text(
+        24.0,
+        body_top + 8.0,
+        12.0,
+        120,
+        130,
+        160,
+        255,
+        if s.body_truncated {
+            "Response body (truncated to 8 KiB):"
+        } else {
+            "Response body:"
+        },
+    );
+
+    // Render the body as wrapped lines of up to ~100 chars. Keep it simple —
+    // the host text shaper handles UTF-8.
+    let text = core::str::from_utf8(&s.body[..s.body_len]).unwrap_or("(non-utf8 body)");
+    let line_h = 16.0;
+    let start_y = body_top + 28.0;
+    let max_lines = ((body_h - 28.0) / line_h) as usize;
+    let mut y = start_y;
+    for (drawn, part) in text.lines().enumerate() {
+        if drawn >= max_lines {
+            break;
+        }
+        canvas_text(24.0, y, 12.0, 210, 220, 230, 255, part);
+        y += line_h;
+    }
+
+    // ── Error line ────────────────────────────────────────────────────────
+    if s.last_error_len > 0 {
+        let err = core::str::from_utf8(&s.last_error[..s.last_error_len]).unwrap_or("?");
+        canvas_text(14.0, h - 16.0, 12.0, 230, 120, 120, 255, err);
+    }
+}
+
+// ── Tiny integer formatters (no heap, writes into caller buffer) ──────────
+
+fn format_u32(buf: &mut [u8; 128], n: u32) -> &str {
+    format_usize(buf, n as usize)
+}
+
+fn format_usize(buf: &mut [u8; 128], mut n: usize) -> &str {
+    if n == 0 {
+        buf[0] = b'0';
+        return core::str::from_utf8(&buf[..1]).unwrap_or("0");
+    }
+    let mut tmp = [0u8; 24];
+    let mut i = 0;
+    while n > 0 {
+        tmp[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        i += 1;
+    }
+    let mut j = 0;
+    while j < i {
+        buf[j] = tmp[i - 1 - j];
+        j += 1;
+    }
+    core::str::from_utf8(&buf[..j]).unwrap_or("")
+}
+
+extern crate alloc;

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -193,6 +193,8 @@ pub struct HostState {
     pub ws: Arc<Mutex<Option<crate::websocket::WsState>>>,
     /// MIDI input/output connections (lazily initialised on first midi_open call).
     pub midi: Arc<Mutex<Option<crate::midi::MidiState>>>,
+    /// Streaming / non-blocking fetch state (lazily initialised on first `api_fetch_begin`).
+    pub fetch: Arc<Mutex<Option<crate::fetch::FetchState>>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -563,6 +565,7 @@ impl Default for HostState {
             rtc: Arc::new(Mutex::new(None)),
             ws: Arc::new(Mutex::new(None)),
             midi: Arc::new(Mutex::new(None)),
+            fetch: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -3498,6 +3501,9 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
 
     // ── MIDI API ──────────────────────────────────────────────────────
     crate::midi::register_midi_functions(linker)?;
+
+    // ── Streaming / non-blocking Fetch API ────────────────────────────
+    crate::fetch::register_fetch_functions(linker)?;
 
     Ok(())
 }

--- a/oxide-browser/src/fetch.rs
+++ b/oxide-browser/src/fetch.rs
@@ -1,0 +1,468 @@
+//! Non-blocking / streaming HTTP fetch for Oxide guest modules.
+//!
+//! The legacy `api_fetch` import (in [`crate::capabilities`]) blocks the guest
+//! until the entire response body has been downloaded. That prevents guests
+//! from rendering frames during large downloads and makes LLM-style
+//! token-streaming, chunked feeds, or progressive image loads impossible.
+//!
+//! This module exposes a second fetch API that is fully async from the guest's
+//! perspective. The shape mirrors [`crate::websocket`]:
+//!
+//! * `api_fetch_begin` dispatches a request and returns a handle immediately.
+//! * `api_fetch_state` / `api_fetch_status` report progress.
+//! * `api_fetch_recv` pulls the next body chunk from an in-memory queue.
+//! * `api_fetch_abort` cancels an in-flight request.
+//! * `api_fetch_remove` frees host-side resources once the guest is done.
+//!
+//! A background tokio task per request drives `reqwest`'s `bytes_stream()`,
+//! pushing chunks into a `VecDeque<Vec<u8>>` drained by the guest.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use futures_util::StreamExt;
+use tokio::runtime::Runtime;
+use wasmtime::{Caller, Linker};
+
+use crate::capabilities::{
+    console_log, read_guest_bytes, read_guest_string, write_guest_bytes, ConsoleLevel, HostState,
+};
+
+// ── Ready-state constants (mirrored in oxide-sdk) ──────────────────────────
+
+/// Request dispatched; waiting for response headers.
+pub const FETCH_PENDING: u32 = 0;
+/// Headers received; body chunks may be streaming in.
+pub const FETCH_STREAMING: u32 = 1;
+/// Body fully delivered and the queue may still contain trailing chunks.
+pub const FETCH_DONE: u32 = 2;
+/// Request failed. Use `api_fetch_error` to retrieve the message.
+pub const FETCH_ERROR: u32 = 3;
+/// Request was aborted by the guest.
+pub const FETCH_ABORTED: u32 = 4;
+
+// ── Recv return-code sentinels (i64, negative) ─────────────────────────────
+
+const RECV_PENDING: i64 = -1;
+const RECV_EOF: i64 = -2;
+const RECV_ERROR: i64 = -3;
+const RECV_UNKNOWN: i64 = -4;
+
+/// Per-request state shared between the host API and the background driver task.
+struct FetchInner {
+    /// One of the `FETCH_*` constants.
+    state: AtomicU32,
+    /// HTTP status code once headers arrive, 0 until then.
+    status: AtomicU32,
+    /// Guest-side signal to stop streaming. Polled by the driver task between chunks.
+    aborted: AtomicBool,
+    /// Queued body chunks. Each `Vec<u8>` is one network chunk; the guest may
+    /// drain them in smaller pieces — see [`FetchState::recv`] for splitting.
+    chunks: Mutex<VecDeque<Vec<u8>>>,
+    /// Last error message (set once before transitioning to [`FETCH_ERROR`]).
+    error: Mutex<Option<String>>,
+}
+
+impl FetchInner {
+    fn new() -> Self {
+        Self {
+            state: AtomicU32::new(FETCH_PENDING),
+            status: AtomicU32::new(0),
+            aborted: AtomicBool::new(false),
+            chunks: Mutex::new(VecDeque::new()),
+            error: Mutex::new(None),
+        }
+    }
+
+    fn set_error(&self, msg: impl Into<String>) {
+        *self.error.lock().unwrap() = Some(msg.into());
+        self.state.store(FETCH_ERROR, Ordering::SeqCst);
+    }
+}
+
+/// All streaming-fetch state for a host. Lazily initialised on the first
+/// `api_fetch_begin` call.
+pub struct FetchState {
+    runtime: Runtime,
+    handles: HashMap<u32, Arc<FetchInner>>,
+    next_id: u32,
+}
+
+impl FetchState {
+    pub fn new() -> Option<Self> {
+        let runtime = Runtime::new().ok()?;
+        Some(Self {
+            runtime,
+            handles: HashMap::new(),
+            next_id: 1,
+        })
+    }
+
+    fn alloc_id(&mut self) -> u32 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        id
+    }
+
+    /// Dispatch a new request. Returns a handle (`> 0`) or `0` on init failure.
+    fn begin(&mut self, method: String, url: String, content_type: String, body: Vec<u8>) -> u32 {
+        let id = self.alloc_id();
+        let inner = Arc::new(FetchInner::new());
+        let driver_inner = inner.clone();
+
+        self.runtime.spawn(async move {
+            drive_request(driver_inner, method, url, content_type, body).await;
+        });
+
+        self.handles.insert(id, inner);
+        id
+    }
+
+    fn state(&self, id: u32) -> u32 {
+        self.handles
+            .get(&id)
+            .map(|h| h.state.load(Ordering::SeqCst))
+            .unwrap_or(FETCH_ERROR)
+    }
+
+    fn status(&self, id: u32) -> u32 {
+        self.handles
+            .get(&id)
+            .map(|h| h.status.load(Ordering::SeqCst))
+            .unwrap_or(0)
+    }
+
+    fn error(&self, id: u32) -> Option<String> {
+        self.handles
+            .get(&id)
+            .and_then(|h| h.error.lock().unwrap().clone())
+    }
+
+    /// Pop up to `cap` bytes from the head of the body queue.
+    ///
+    /// Returns one of the negative sentinels (`RECV_*`) or a non-negative byte
+    /// count. When a single queued chunk is larger than `cap`, the extra bytes
+    /// are re-queued at the front so the next call returns them — no data is
+    /// dropped.
+    fn recv(&self, id: u32, cap: usize) -> RecvResult {
+        let Some(inner) = self.handles.get(&id) else {
+            return RecvResult::Sentinel(RECV_UNKNOWN);
+        };
+
+        let mut q = inner.chunks.lock().unwrap();
+        if let Some(mut chunk) = q.pop_front() {
+            if chunk.len() > cap {
+                let remainder = chunk.split_off(cap);
+                q.push_front(remainder);
+            }
+            return RecvResult::Data(chunk);
+        }
+        drop(q);
+
+        match inner.state.load(Ordering::SeqCst) {
+            FETCH_DONE => RecvResult::Sentinel(RECV_EOF),
+            FETCH_ERROR | FETCH_ABORTED => RecvResult::Sentinel(RECV_ERROR),
+            _ => RecvResult::Sentinel(RECV_PENDING),
+        }
+    }
+
+    fn abort(&self, id: u32) -> bool {
+        if let Some(inner) = self.handles.get(&id) {
+            inner.aborted.store(true, Ordering::SeqCst);
+            // Flip state immediately so `state()` reports the intent even
+            // before the driver task observes the flag.
+            let _ = inner.state.compare_exchange(
+                FETCH_PENDING,
+                FETCH_ABORTED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+            let _ = inner.state.compare_exchange(
+                FETCH_STREAMING,
+                FETCH_ABORTED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    fn remove(&mut self, id: u32) {
+        if let Some(inner) = self.handles.remove(&id) {
+            inner.aborted.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+enum RecvResult {
+    Data(Vec<u8>),
+    Sentinel(i64),
+}
+
+/// Background task body: run the request and feed chunks into `inner`.
+async fn drive_request(
+    inner: Arc<FetchInner>,
+    method: String,
+    url: String,
+    content_type: String,
+    body: Vec<u8>,
+) {
+    if inner.aborted.load(Ordering::SeqCst) {
+        inner.state.store(FETCH_ABORTED, Ordering::SeqCst);
+        return;
+    }
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            inner.set_error(format!("client build failed: {e}"));
+            return;
+        }
+    };
+
+    let parsed_method: reqwest::Method = method.parse().unwrap_or(reqwest::Method::GET);
+    let mut req = client.request(parsed_method, &url);
+    if !content_type.is_empty() {
+        req = req.header("Content-Type", &content_type);
+    }
+    if !body.is_empty() {
+        req = req.body(body);
+    }
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            inner.set_error(e.to_string());
+            return;
+        }
+    };
+
+    if inner.aborted.load(Ordering::SeqCst) {
+        inner.state.store(FETCH_ABORTED, Ordering::SeqCst);
+        return;
+    }
+
+    inner
+        .status
+        .store(resp.status().as_u16() as u32, Ordering::SeqCst);
+    inner.state.store(FETCH_STREAMING, Ordering::SeqCst);
+
+    let mut stream = resp.bytes_stream();
+    while let Some(next) = stream.next().await {
+        if inner.aborted.load(Ordering::SeqCst) {
+            inner.state.store(FETCH_ABORTED, Ordering::SeqCst);
+            return;
+        }
+        match next {
+            Ok(chunk) => {
+                if !chunk.is_empty() {
+                    inner.chunks.lock().unwrap().push_back(chunk.to_vec());
+                }
+            }
+            Err(e) => {
+                inner.set_error(e.to_string());
+                return;
+            }
+        }
+    }
+
+    // Preserve ABORTED if the guest aborted between the final chunk and here.
+    let _ = inner.state.compare_exchange(
+        FETCH_STREAMING,
+        FETCH_DONE,
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+    );
+}
+
+fn ensure_fetch(state: &Arc<Mutex<Option<FetchState>>>) -> bool {
+    let mut g = state.lock().unwrap();
+    if g.is_none() {
+        *g = FetchState::new();
+    }
+    g.is_some()
+}
+
+/// Register all `api_fetch_*` streaming host functions on the given linker.
+pub fn register_fetch_functions(linker: &mut Linker<HostState>) -> Result<()> {
+    // ── fetch_begin ──────────────────────────────────────────────────────
+    // api_fetch_begin(method_ptr, method_len, url_ptr, url_len,
+    //                 ct_ptr, ct_len, body_ptr, body_len) -> u32
+    //   Returns a handle (> 0), or 0 on error.
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_begin",
+        |caller: Caller<'_, HostState>,
+         method_ptr: u32,
+         method_len: u32,
+         url_ptr: u32,
+         url_len: u32,
+         ct_ptr: u32,
+         ct_len: u32,
+         body_ptr: u32,
+         body_len: u32|
+         -> u32 {
+            let console = caller.data().console.clone();
+            let fetch = caller.data().fetch.clone();
+            if !ensure_fetch(&fetch) {
+                console_log(&console, ConsoleLevel::Error, "[FETCH] Init failed".into());
+                return 0;
+            }
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let method =
+                read_guest_string(&mem, &caller, method_ptr, method_len).unwrap_or_default();
+            let url = read_guest_string(&mem, &caller, url_ptr, url_len).unwrap_or_default();
+            let content_type = read_guest_string(&mem, &caller, ct_ptr, ct_len).unwrap_or_default();
+            let body = if body_len > 0 {
+                read_guest_bytes(&mem, &caller, body_ptr, body_len).unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+
+            let id = fetch.lock().unwrap().as_mut().unwrap().begin(
+                method.clone(),
+                url.clone(),
+                content_type,
+                body,
+            );
+
+            console_log(
+                &console,
+                ConsoleLevel::Log,
+                format!("[FETCH] {method} {url} (id={id})"),
+            );
+            id
+        },
+    )?;
+
+    // ── fetch_state ──────────────────────────────────────────────────────
+    // api_fetch_state(id) -> u32  (one of FETCH_* constants)
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_state",
+        |caller: Caller<'_, HostState>, id: u32| -> u32 {
+            let fetch = caller.data().fetch.clone();
+            let g = fetch.lock().unwrap();
+            g.as_ref().map(|s| s.state(id)).unwrap_or(FETCH_ERROR)
+        },
+    )?;
+
+    // ── fetch_status ─────────────────────────────────────────────────────
+    // api_fetch_status(id) -> u32  (HTTP status, 0 before headers)
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_status",
+        |caller: Caller<'_, HostState>, id: u32| -> u32 {
+            let fetch = caller.data().fetch.clone();
+            let g = fetch.lock().unwrap();
+            g.as_ref().map(|s| s.status(id)).unwrap_or(0)
+        },
+    )?;
+
+    // ── fetch_recv ───────────────────────────────────────────────────────
+    // api_fetch_recv(id, out_ptr, out_cap) -> i64
+    //   >= 0 : bytes written into `out_ptr` (one chunk, possibly partial)
+    //   -1   : pending (no chunk available, more may arrive)
+    //   -2   : end of stream (body fully delivered)
+    //   -3   : error (see api_fetch_error)
+    //   -4   : unknown handle
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_recv",
+        |mut caller: Caller<'_, HostState>, id: u32, out_ptr: u32, out_cap: u32| -> i64 {
+            let fetch = caller.data().fetch.clone();
+            let result = {
+                let g = fetch.lock().unwrap();
+                match g.as_ref() {
+                    Some(s) => s.recv(id, out_cap as usize),
+                    None => return RECV_UNKNOWN,
+                }
+            };
+            match result {
+                RecvResult::Sentinel(code) => code,
+                RecvResult::Data(bytes) => {
+                    let mem = match caller.data().memory {
+                        Some(m) => m,
+                        None => return RECV_ERROR,
+                    };
+                    if write_guest_bytes(&mem, &mut caller, out_ptr, &bytes).is_err() {
+                        return RECV_ERROR;
+                    }
+                    bytes.len() as i64
+                }
+            }
+        },
+    )?;
+
+    // ── fetch_error ──────────────────────────────────────────────────────
+    // api_fetch_error(id, out_ptr, out_cap) -> i32
+    //   >= 0 : number of UTF-8 bytes written (possibly truncated)
+    //   -1   : no error set
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_error",
+        |mut caller: Caller<'_, HostState>, id: u32, out_ptr: u32, out_cap: u32| -> i32 {
+            let fetch = caller.data().fetch.clone();
+            let msg = {
+                let g = fetch.lock().unwrap();
+                g.as_ref().and_then(|s| s.error(id))
+            };
+            let msg = match msg {
+                Some(m) => m,
+                None => return -1,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let bytes = msg.as_bytes();
+            let n = bytes.len().min(out_cap as usize);
+            if write_guest_bytes(&mem, &mut caller, out_ptr, &bytes[..n]).is_err() {
+                return -1;
+            }
+            n as i32
+        },
+    )?;
+
+    // ── fetch_abort ──────────────────────────────────────────────────────
+    // api_fetch_abort(id) -> i32  (1 if aborted, 0 if unknown handle)
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_abort",
+        |caller: Caller<'_, HostState>, id: u32| -> i32 {
+            let fetch = caller.data().fetch.clone();
+            let g = fetch.lock().unwrap();
+            match g.as_ref() {
+                Some(s) => i32::from(s.abort(id)),
+                None => 0,
+            }
+        },
+    )?;
+
+    // ── fetch_remove ─────────────────────────────────────────────────────
+    // api_fetch_remove(id)  — free host-side resources.
+    linker.func_wrap(
+        "oxide",
+        "api_fetch_remove",
+        |caller: Caller<'_, HostState>, id: u32| {
+            let fetch = caller.data().fetch.clone();
+            let mut g = fetch.lock().unwrap();
+            if let Some(ref mut state) = *g {
+                state.remove(id);
+            }
+        },
+    )?;
+
+    Ok(())
+}

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -101,6 +101,7 @@ pub mod bookmarks;
 pub mod capabilities;
 pub mod download;
 pub mod engine;
+pub mod fetch;
 pub mod gpu;
 pub mod history;
 pub mod media_capture;

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -90,6 +90,7 @@
 //! | **GPU** | [`gpu_create_buffer`], [`gpu_create_texture`], [`gpu_create_shader`], [`gpu_create_pipeline`], [`gpu_draw`], [`gpu_dispatch_compute`] |
 //! | **Console** | [`log`], [`warn`], [`error`] |
 //! | **HTTP** | [`fetch`], [`fetch_get`], [`fetch_post`], [`fetch_post_proto`], [`fetch_put`], [`fetch_delete`] |
+//! | **HTTP (streaming)** | [`fetch_begin`], [`fetch_begin_get`], [`fetch_state`], [`fetch_status`], [`fetch_recv`], [`fetch_error`], [`fetch_abort`], [`fetch_remove`] |
 //! | **Protobuf** | [`proto::ProtoEncoder`], [`proto::ProtoDecoder`] |
 //! | **Storage** | [`storage_set`], [`storage_get`], [`storage_remove`], [`kv_store_set`], [`kv_store_get`], [`kv_store_delete`] |
 //! | **Audio** | [`audio_play`], [`audio_play_url`], [`audio_detect_format`], [`audio_play_with_format`], [`audio_pause`], [`audio_channel_play`] |
@@ -315,6 +316,36 @@ extern "C" {
         out_ptr: u32,
         out_cap: u32,
     ) -> i64;
+
+    #[link_name = "api_fetch_begin"]
+    fn _api_fetch_begin(
+        method_ptr: u32,
+        method_len: u32,
+        url_ptr: u32,
+        url_len: u32,
+        ct_ptr: u32,
+        ct_len: u32,
+        body_ptr: u32,
+        body_len: u32,
+    ) -> u32;
+
+    #[link_name = "api_fetch_state"]
+    fn _api_fetch_state(id: u32) -> u32;
+
+    #[link_name = "api_fetch_status"]
+    fn _api_fetch_status(id: u32) -> u32;
+
+    #[link_name = "api_fetch_recv"]
+    fn _api_fetch_recv(id: u32, out_ptr: u32, out_cap: u32) -> i64;
+
+    #[link_name = "api_fetch_error"]
+    fn _api_fetch_error(id: u32, out_ptr: u32, out_cap: u32) -> i32;
+
+    #[link_name = "api_fetch_abort"]
+    fn _api_fetch_abort(id: u32) -> i32;
+
+    #[link_name = "api_fetch_remove"]
+    fn _api_fetch_remove(id: u32);
 
     #[link_name = "api_load_module"]
     fn _api_load_module(url_ptr: u32, url_len: u32) -> i32;
@@ -2214,6 +2245,137 @@ pub fn fetch_put(url: &str, content_type: &str, body: &[u8]) -> Result<FetchResp
 /// HTTP DELETE.
 pub fn fetch_delete(url: &str) -> Result<FetchResponse, i64> {
     fetch("DELETE", url, "", &[])
+}
+
+// ─── Streaming / non-blocking fetch ─────────────────────────────────────────
+//
+// The [`fetch`] family above blocks the guest until the response is fully
+// downloaded. For LLM token streams, large downloads, chunked feeds, or any
+// app that wants to keep rendering while a request is in flight, use the
+// handle-based API below. It mirrors the WebSocket API: dispatch with
+// `fetch_begin`, then poll `fetch_state`, `fetch_status`, and `fetch_recv`.
+
+/// Request dispatched; waiting for response headers.
+pub const FETCH_PENDING: u32 = 0;
+/// Headers received; body chunks may still be arriving.
+pub const FETCH_STREAMING: u32 = 1;
+/// Body fully delivered (the queue may still have trailing chunks to drain).
+pub const FETCH_DONE: u32 = 2;
+/// Request failed. Call [`fetch_error`] for the message.
+pub const FETCH_ERROR: u32 = 3;
+/// Request was aborted by the guest.
+pub const FETCH_ABORTED: u32 = 4;
+
+/// Result of a non-blocking [`fetch_recv`] poll.
+pub enum FetchChunk {
+    /// One body chunk (may be part of a larger network chunk if it didn't fit
+    /// in the caller's buffer).
+    Data(Vec<u8>),
+    /// No chunk is available right now, but more may still arrive. Call
+    /// [`fetch_recv`] again next frame.
+    Pending,
+    /// The body has been fully delivered and all chunks have been drained.
+    End,
+    /// The request failed or was aborted. Inspect [`fetch_state`] and
+    /// [`fetch_error`] for details.
+    Error,
+}
+
+/// Dispatch an HTTP request that streams its response back to the guest.
+///
+/// Returns a handle (`> 0`) that identifies the request for subsequent polls,
+/// or `0` if the host could not initialise the fetch subsystem. The call
+/// returns immediately — the request is driven by a background task.
+///
+/// Pass `""` for `content_type` to omit the header, and `&[]` for `body` on
+/// requests without a payload.
+pub fn fetch_begin(method: &str, url: &str, content_type: &str, body: &[u8]) -> u32 {
+    unsafe {
+        _api_fetch_begin(
+            method.as_ptr() as u32,
+            method.len() as u32,
+            url.as_ptr() as u32,
+            url.len() as u32,
+            content_type.as_ptr() as u32,
+            content_type.len() as u32,
+            body.as_ptr() as u32,
+            body.len() as u32,
+        )
+    }
+}
+
+/// Convenience wrapper for GET.
+pub fn fetch_begin_get(url: &str) -> u32 {
+    fetch_begin("GET", url, "", &[])
+}
+
+/// Current lifecycle state of a streaming request. See the `FETCH_*` constants.
+pub fn fetch_state(handle: u32) -> u32 {
+    unsafe { _api_fetch_state(handle) }
+}
+
+/// HTTP status code for `handle`, or `0` until the response headers arrive.
+pub fn fetch_status(handle: u32) -> u32 {
+    unsafe { _api_fetch_status(handle) }
+}
+
+/// Poll the next body chunk into a caller-provided scratch buffer.
+///
+/// Use this form when you want to avoid per-chunk heap allocations. Prefer
+/// [`fetch_recv`] for ergonomics in higher-level code.
+///
+/// Returns the number of bytes written into `buf` (which may be smaller than
+/// the chunk the host has queued — in which case the remainder will be
+/// returned on the next call), or one of the negative sentinels documented by
+/// the host (`-1` pending, `-2` EOF, `-3` error, `-4` unknown handle).
+pub fn fetch_recv_into(handle: u32, buf: &mut [u8]) -> i64 {
+    unsafe { _api_fetch_recv(handle, buf.as_mut_ptr() as u32, buf.len() as u32) }
+}
+
+/// Poll the next body chunk as an owned `Vec<u8>`.
+///
+/// Chunks larger than 64 KiB are read in 64 KiB slices; call `fetch_recv`
+/// repeatedly to drain the full network chunk.
+pub fn fetch_recv(handle: u32) -> FetchChunk {
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = fetch_recv_into(handle, &mut buf);
+    match n {
+        -1 => FetchChunk::Pending,
+        -2 => FetchChunk::End,
+        -3 | -4 => FetchChunk::Error,
+        n if n >= 0 => {
+            buf.truncate(n as usize);
+            FetchChunk::Data(buf)
+        }
+        _ => FetchChunk::Error,
+    }
+}
+
+/// Retrieve the error message for a failed request, if any.
+pub fn fetch_error(handle: u32) -> Option<String> {
+    let mut buf = [0u8; 512];
+    let n = unsafe { _api_fetch_error(handle, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    if n < 0 {
+        None
+    } else {
+        Some(String::from_utf8_lossy(&buf[..n as usize]).into_owned())
+    }
+}
+
+/// Abort an in-flight request. Returns `true` if the handle was known.
+///
+/// The request transitions to [`FETCH_ABORTED`]; any body chunks already
+/// queued remain readable via [`fetch_recv`] until drained.
+pub fn fetch_abort(handle: u32) -> bool {
+    unsafe { _api_fetch_abort(handle) != 0 }
+}
+
+/// Free host-side resources for a completed or aborted request.
+///
+/// Call this once you've finished draining [`fetch_recv`]. After removal the
+/// handle is invalid.
+pub fn fetch_remove(handle: u32) {
+    unsafe { _api_fetch_remove(handle) }
 }
 
 // ─── Dynamic Module Loading ─────────────────────────────────────────────────


### PR DESCRIPTION
The existing api_fetch blocks the guest until the whole response body is downloaded, which freezes the frame loop and makes LLM token streams, chunked feeds, and progressive downloads impossible. This adds a second, handle-based fetch API that returns immediately and streams body chunks into the guest as they arrive.

Host (oxide-browser/src/fetch.rs — new module)

* FetchState: lazily-initialised tokio Runtime + HashMap<u32, Arc<FetchInner>>.
* Each api_fetch_begin spawns an async task that drives reqwest's Client::send() and then bytes_stream(), pushing chunks into a Mutex<VecDeque<Vec<u8>>>.
* AtomicU32 ready-state and HTTP status; AtomicBool abort flag checked between chunks so cancellation is prompt.

New host functions (all in the "oxide" import module):

* api_fetch_begin(method, url, content_type, body) -> u32 handle
* api_fetch_state(id) -> u32 0 PENDING / 1 STREAMING / 2 DONE / 3 ERROR / 4 ABORTED
* api_fetch_status(id) -> u32 (HTTP status, 0 until headers arrive)
* api_fetch_recv(id, ptr, cap) -> i64
    >=0 bytes written, -1 pending, -2 EOF, -3 error, -4 unknown handle.
    Chunks larger than cap are split and the remainder is re-queued at
    the front so no bytes are dropped.
* api_fetch_error(id, ptr, cap) -> i32
* api_fetch_abort(id), api_fetch_remove(id)

The existing synchronous api_fetch is untouched for back-compat.

HostState (oxide-browser/src/capabilities.rs)

* New fetch: Arc<Mutex<Option<crate::fetch::FetchState>>> field, initialised to None and registered via crate::fetch::register_fetch_functions at the bottom of register_host_functions.

SDK (oxide-sdk/src/lib.rs)

* extern "C" imports for all seven api_fetch_* functions.
* Public wrappers: fetch_begin, fetch_begin_get, fetch_state, fetch_status, fetch_recv (returns FetchChunk::{Data, Pending, End, Error}), fetch_recv_into (zero-alloc), fetch_error, fetch_abort, fetch_remove.
* FETCH_* ready-state constants and a new "HTTP (streaming)" row in the module-level API table.

Example

* examples/stream-fetch-demo: progressive UI with state badge, HTTP status, byte / chunk counters, live body preview, and Abort / Restart buttons. Defaults to httpbin.org/drip so the streaming behaviour is observable by default. Added to the workspace members list.

Roadmap

* Tick "Non-blocking fetch with callback/promise-style API" and "Streaming response bodies (chunked transfer)" in Phase 4 Async I/O.

Verification

* cargo fmt --all
* cargo clippy --workspace --all-targets -- -D warnings
* cargo test --workspace
* cargo build -p oxide-browser
* cargo build --target wasm32-unknown-unknown --release -p stream-fetch-demo

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming HTTP fetch API enabling non-blocking, chunked response handling with support for aborting and monitoring request progress in real-time.
  * Added interactive demo showcasing streaming fetch functionality with live UI updates.

* **Documentation**
  * Updated roadmap marking streaming responses and non-blocking fetch as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->