### PR TITLE
feat(worker): background WASM workers with isolated fuel/memory and m…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10785,6 +10785,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "worker-demo"
+version = "0.1.0"
+dependencies = [
+ "oxide-sdk",
+]
+
+[[package]]
+name = "worker-demo-bg"
+version = "0.1.0"
+dependencies = [
+ "oxide-sdk",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,7 @@ members = [
     "examples/gradient-demo",
     "examples/typography-demo",
     "examples/shadcn-demo",
+    "examples/worker-demo",
+    "examples/worker-demo-bg",
 ]
 resolver = "2"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -194,11 +194,11 @@ The core architecture is live: a Rust-native browser that fetches and executes `
 
 ### Background Workers
 
-- [ ] `spawn_worker(wasm_url)` — launch a background WASM worker with its own fuel and memory
-- [ ] `worker_post_message(worker_id, data)` / `worker_on_message(worker_id, callback)`
+- [x] `spawn_worker(wasm_url)` — launch a background WASM worker with its own fuel and memory
+- [x] `worker_post_message(worker_id, data)` / worker `on_message(len)` export (replies polled via `worker_recv`)
 - [ ] Shared memory regions between main module and workers (opt-in)
 - [ ] Worker pool management and load balancing
-- [ ] `worker_terminate(worker_id)` — graceful and forced termination
+- [x] `worker_terminate(worker_id)` — graceful and forced termination
 
 ### System APIs
 

--- a/examples/worker-demo-bg/Cargo.toml
+++ b/examples/worker-demo-bg/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "worker-demo-bg"
+version = "0.1.0"
+edition = "2021"
+description = "Background worker demo for the Oxide browser (worker module)"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/worker-demo-bg/src/lib.rs
+++ b/examples/worker-demo-bg/src/lib.rs
@@ -1,0 +1,53 @@
+//! Background worker demo — worker module.
+//!
+//! Loaded by `worker-demo` via [`spawn_worker`]. Receives a single `u32` limit
+//! (little-endian) through `on_message`, counts the primes below it on its own
+//! thread, and posts the count back as a little-endian `u64`.
+//!
+//! # Building
+//!
+//! ```bash
+//! cargo build --target wasm32-unknown-unknown --release -p worker-demo-bg
+//! ```
+
+use oxide_sdk::*;
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("[worker] ready, waiting for work.");
+}
+
+#[no_mangle]
+pub extern "C" fn on_message(_len: u32) {
+    let mut buf = [0u8; 4];
+    let n = worker_message_read(&mut buf);
+    if n < 4 {
+        return;
+    }
+    let limit = u32::from_le_bytes(buf);
+
+    let mut count: u64 = 0;
+    let mut k: u32 = 2;
+    while k < limit {
+        if is_prime(k) {
+            count += 1;
+        }
+        k += 1;
+    }
+
+    worker_post(&count.to_le_bytes());
+}
+
+fn is_prime(n: u32) -> bool {
+    if n < 2 {
+        return false;
+    }
+    let mut d = 2u32;
+    while d * d <= n {
+        if n.is_multiple_of(d) {
+            return false;
+        }
+        d += 1;
+    }
+    true
+}

--- a/examples/worker-demo/Cargo.toml
+++ b/examples/worker-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "worker-demo"
+version = "0.1.0"
+edition = "2021"
+description = "Background worker demo for the Oxide browser (main app)"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/worker-demo/src/lib.rs
+++ b/examples/worker-demo/src/lib.rs
@@ -1,0 +1,136 @@
+//! Background worker demo — main app.
+//!
+//! Offloads a CPU-heavy prime count to a separate `.wasm` worker module so the
+//! UI frame loop never blocks. The worker (`worker-demo-bg`) runs on its own
+//! thread with isolated fuel and memory; the two communicate only by passing
+//! byte messages.
+//!
+//! # Building
+//!
+//! ```bash
+//! cargo build --target wasm32-unknown-unknown --release -p worker-demo
+//! cargo build --target wasm32-unknown-unknown --release -p worker-demo-bg
+//! ```
+//!
+//! Both `.wasm` files land in the same directory, so the worker URL is resolved
+//! relative to this module's URL at runtime.
+
+use oxide_sdk::*;
+
+/// Upper bound for the prime count handed to the worker.
+const LIMIT: u32 = 80_000;
+
+static mut STATE: State = State::new();
+
+struct State {
+    /// Handle of the spawned worker (0 = none).
+    handle: u32,
+    /// 0 = idle, 1 = computing, 2 = done.
+    phase: u8,
+    /// Result returned by the worker.
+    result: u64,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            handle: 0,
+            phase: 0,
+            result: 0,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("Background worker demo loaded.");
+}
+
+#[no_mangle]
+pub extern "C" fn on_frame(_dt_ms: u32) {
+    let s = unsafe { &mut *core::ptr::addr_of_mut!(STATE) };
+    let (w, _h) = canvas_dimensions();
+
+    canvas_clear(18, 18, 28, 255);
+    canvas_text(
+        20.0,
+        20.0,
+        24.0,
+        220,
+        200,
+        255,
+        255,
+        "Background Workers Demo",
+    );
+    canvas_text(
+        20.0,
+        56.0,
+        14.0,
+        150,
+        150,
+        170,
+        255,
+        &format!("Count primes below {LIMIT} on a separate worker thread."),
+    );
+    canvas_text(
+        20.0,
+        76.0,
+        14.0,
+        150,
+        150,
+        170,
+        255,
+        "The spinner keeps moving, proving the UI thread never blocks.",
+    );
+
+    if ui_button(1, 20.0, 110.0, 240.0, 32.0, "Run in background worker") {
+        let base = get_url();
+        if let Some(url) = url_resolve(&base, "worker_demo_bg.wasm") {
+            let handle = spawn_worker(&url);
+            if handle > 0 {
+                s.handle = handle as u32;
+                s.phase = 1;
+                s.result = 0;
+                worker_post_message(s.handle, &LIMIT.to_le_bytes());
+            } else {
+                log("Failed to spawn worker.");
+            }
+        } else {
+            log("Could not resolve worker URL.");
+        }
+    }
+
+    // Non-blocking poll for the worker's reply.
+    if s.phase == 1 {
+        if let Some(bytes) = worker_recv(s.handle) {
+            if bytes.len() >= 8 {
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(&bytes[..8]);
+                s.result = u64::from_le_bytes(arr);
+                s.phase = 2;
+                worker_terminate(s.handle);
+            }
+        }
+    }
+
+    let status = match s.phase {
+        0 => "Idle — click the button to start.".to_string(),
+        1 => "Computing on worker…".to_string(),
+        _ => format!("Done: {} primes below {LIMIT}.", s.result),
+    };
+    canvas_text(20.0, 165.0, 16.0, 160, 220, 160, 255, &status);
+
+    // Spinner animated purely from the main frame loop.
+    let t = (time_now_ms() as f32) / 1000.0;
+    let cx = w as f32 - 60.0;
+    let cy = 126.0;
+    canvas_circle(
+        cx + (t * 3.0).cos() * 18.0,
+        cy + (t * 3.0).sin() * 18.0,
+        7.0,
+        120,
+        180,
+        255,
+        255,
+    );
+}

--- a/oxide-browser/src/capabilities.rs
+++ b/oxide-browser/src/capabilities.rs
@@ -222,6 +222,15 @@ pub struct HostState {
     pub scroll_x: Arc<Mutex<f32>>,
     /// Absolute scroll vertical offset.
     pub scroll_y: Arc<Mutex<f32>>,
+    /// Background workers spawned by this guest, keyed by handle. Lazily
+    /// initialised on the first `api_spawn_worker` call. See [`crate::worker`].
+    pub workers: Arc<Mutex<Option<crate::worker::WorkerState>>>,
+    /// Outbound message queue, present **only** inside a worker's own state.
+    /// `api_worker_post` pushes here; the parent drains it via `api_worker_recv`.
+    pub worker_outbox: Option<Arc<Mutex<std::collections::VecDeque<Vec<u8>>>>>,
+    /// Message currently being delivered to a worker's `on_message` export,
+    /// read by `api_worker_message_read` during the callback.
+    pub worker_current_msg: Arc<Mutex<Option<Vec<u8>>>>,
 }
 
 /// A single console log line: local time, severity, and message text.
@@ -709,6 +718,9 @@ impl Default for HostState {
             content_height: Arc::new(Mutex::new(0)),
             scroll_x: Arc::new(Mutex::new(0.0)),
             scroll_y: Arc::new(Mutex::new(0.0)),
+            workers: Arc::new(Mutex::new(None)),
+            worker_outbox: None,
+            worker_current_msg: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -4413,6 +4425,9 @@ pub fn register_host_functions(linker: &mut Linker<HostState>) -> Result<()> {
 
     // ── Native File / Folder Picker API ───────────────────────────────
     crate::file_picker::register_file_picker_functions(linker)?;
+
+    // ── Background Workers API ────────────────────────────────────────
+    crate::worker::register_worker_functions(linker)?;
 
     // ── Download Manager API ──────────────────────────────────────────
 

--- a/oxide-browser/src/lib.rs
+++ b/oxide-browser/src/lib.rs
@@ -49,6 +49,7 @@
 //! | [`media_capture`] | Camera, microphone, and screen capture with permission prompts |
 //! | [`rtc`] | WebRTC peer connections, data channels, media tracks, and signaling |
 //! | [`websocket`] | WebSocket client connections (text/binary frames, ready-state polling) |
+//! | [`worker`] | Background WASM workers with isolated fuel/memory and message passing |
 //! | [`midi`] | MIDI input/output device enumeration and I/O (CoreMIDI on macOS) |
 //! | [`navigation`] | Browser history stack with back/forward traversal |
 //! | [`bookmarks`] | Persistent bookmark storage backed by sled |
@@ -119,6 +120,7 @@ pub mod url;
 pub mod video;
 pub mod video_format;
 pub mod websocket;
+pub mod worker;
 
 /// GPU-accelerated UI framework used by the desktop shell (see [GPUI](https://www.gpui.rs/)).
 ///

--- a/oxide-browser/src/worker.rs
+++ b/oxide-browser/src/worker.rs
@@ -1,0 +1,452 @@
+//! Background WebAssembly workers for Oxide guest modules.
+//!
+//! A worker is a separate `.wasm` module instantiated on its own OS thread with
+//! its own Wasmtime [`Store`], fuel budget, and linear memory. It never shares
+//! Rust types or memory with the spawning guest — communication is pure message
+//! passing of byte slices, mirroring the rest of the FFI boundary.
+//!
+//! The spawning ("parent") guest calls:
+//! - `api_spawn_worker(url)` → handle
+//! - `api_worker_post_message(handle, bytes)` — parent → worker inbox
+//! - `api_worker_recv(handle)` — drain one message from the worker's outbox
+//! - `api_worker_terminate(handle)`
+//!
+//! The worker module exports `start_app()` (run once on spawn) and optionally
+//! `on_message(len)` (run for each inbound message). Inside `on_message` it reads
+//! the payload with `api_worker_message_read` and replies with `api_worker_post`.
+//!
+//! All of this is driven by polling from the guest's frame loop, matching the
+//! WebSocket / fetch / RTC subsystems.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use wasmtime::*;
+
+use crate::capabilities::{
+    console_log, read_guest_bytes, read_guest_string, register_host_functions, write_guest_bytes,
+    ConsoleEntry, ConsoleLevel, HostState,
+};
+use crate::engine::ModuleLoader;
+use crate::url::OxideUrl;
+
+/// Message handed to a worker thread over its inbox channel.
+enum Inbox {
+    /// A byte payload to deliver to the worker's `on_message` export.
+    Message(Vec<u8>),
+    /// Request the worker thread to stop.
+    Terminate,
+}
+
+/// Parent-side handle to a single running worker.
+struct Worker {
+    /// Sender for the worker's inbox (parent → worker).
+    inbox_tx: Sender<Inbox>,
+    /// Messages the worker posted back (worker → parent), drained by `api_worker_recv`.
+    outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    /// Cleared on terminate so the worker loop exits after its current callback.
+    alive: Arc<AtomicBool>,
+}
+
+/// Registry of workers spawned by one guest. Lazily created on first spawn.
+pub struct WorkerState {
+    workers: HashMap<u32, Worker>,
+    next_id: u32,
+}
+
+impl WorkerState {
+    fn new() -> Self {
+        Self {
+            workers: HashMap::new(),
+            next_id: 1,
+        }
+    }
+
+    fn alloc_id(&mut self) -> u32 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        id
+    }
+
+    /// Spawn a worker for `url`, deriving its sandbox state from `parent`.
+    ///
+    /// Returns a handle (`> 0`) or `0` if no module loader is available. The
+    /// worker shares only the persistent KV store and console with its parent;
+    /// canvas, input, timers, and memory are isolated.
+    fn spawn(&mut self, url: String, parent: &HostState) -> u32 {
+        let loader = match parent.module_loader.clone() {
+            Some(l) => l,
+            None => return 0,
+        };
+
+        let id = self.alloc_id();
+        let (inbox_tx, inbox_rx) = std::sync::mpsc::channel::<Inbox>();
+        let outbox: Arc<Mutex<VecDeque<Vec<u8>>>> = Arc::new(Mutex::new(VecDeque::new()));
+        let alive = Arc::new(AtomicBool::new(true));
+
+        let child = HostState {
+            module_loader: Some(loader.clone()),
+            kv_db: parent.kv_db.clone(),
+            console: parent.console.clone(),
+            current_url: Arc::new(Mutex::new(url.clone())),
+            worker_outbox: Some(outbox.clone()),
+            worker_current_msg: Arc::new(Mutex::new(None)),
+            ..Default::default()
+        };
+
+        let console = parent.console.clone();
+        let alive_thread = alive.clone();
+        std::thread::spawn(move || {
+            worker_main(url, loader, child, inbox_rx, alive_thread, console);
+        });
+
+        self.workers.insert(
+            id,
+            Worker {
+                inbox_tx,
+                outbox,
+                alive,
+            },
+        );
+        id
+    }
+
+    fn post(&self, id: u32, data: Vec<u8>) -> bool {
+        match self.workers.get(&id) {
+            Some(w) => w.inbox_tx.send(Inbox::Message(data)).is_ok(),
+            None => false,
+        }
+    }
+
+    fn recv(&self, id: u32) -> Option<Vec<u8>> {
+        self.workers.get(&id)?.outbox.lock().unwrap().pop_front()
+    }
+
+    fn terminate(&mut self, id: u32) -> bool {
+        match self.workers.remove(&id) {
+            Some(w) => {
+                w.alive.store(false, Ordering::Relaxed);
+                let _ = w.inbox_tx.send(Inbox::Terminate);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+fn ensure_workers(state: &Arc<Mutex<Option<WorkerState>>>) {
+    let mut g = state.lock().unwrap();
+    if g.is_none() {
+        *g = Some(WorkerState::new());
+    }
+}
+
+/// Synchronously fetch a worker module's bytes. Supports `http(s)` and `file://`.
+fn fetch_worker_bytes(url: &str) -> Result<Vec<u8>> {
+    let parsed = OxideUrl::parse(url).map_err(|e| anyhow::anyhow!("{e}"))?;
+    if parsed.is_fetchable() {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()?;
+        let resp = client
+            .get(parsed.as_str())
+            .header("Accept", "application/wasm")
+            .send()?;
+        if !resp.status().is_success() {
+            anyhow::bail!("HTTP {}", resp.status());
+        }
+        Ok(resp.bytes()?.to_vec())
+    } else if parsed.is_local_file() {
+        let path = parsed
+            .to_file_path()
+            .ok_or_else(|| anyhow::anyhow!("cannot convert file URL to path: {url}"))?;
+        Ok(std::fs::read(&path)?)
+    } else {
+        anyhow::bail!("unsupported worker URL scheme: {}", parsed.scheme())
+    }
+}
+
+/// Body of a worker thread: fetch, compile, instantiate, run `start_app`, then
+/// loop delivering inbound messages to `on_message` until terminated.
+fn worker_main(
+    url: String,
+    loader: Arc<ModuleLoader>,
+    host_state: HostState,
+    inbox_rx: Receiver<Inbox>,
+    alive: Arc<AtomicBool>,
+    console: Arc<Mutex<Vec<ConsoleEntry>>>,
+) {
+    let wasm_bytes = match fetch_worker_bytes(&url) {
+        Ok(b) => b,
+        Err(e) => {
+            console_log(
+                &console,
+                ConsoleLevel::Error,
+                format!("[WORKER] fetch failed for {url}: {e}"),
+            );
+            return;
+        }
+    };
+
+    let module = match Module::new(&loader.engine, &wasm_bytes) {
+        Ok(m) => m,
+        Err(e) => {
+            console_log(
+                &console,
+                ConsoleLevel::Error,
+                format!("[WORKER] compile failed: {e}"),
+            );
+            return;
+        }
+    };
+
+    let mut store = Store::new(&loader.engine, host_state);
+    if store.set_fuel(loader.fuel_limit).is_err() {
+        return;
+    }
+
+    let mut linker = Linker::new(&loader.engine);
+    if register_host_functions(&mut linker).is_err() {
+        return;
+    }
+
+    let mem_type = MemoryType::new(1, Some(loader.max_memory_pages));
+    let memory = match Memory::new(&mut store, mem_type) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    if linker.define(&store, "oxide", "memory", memory).is_err() {
+        return;
+    }
+    store.data_mut().memory = Some(memory);
+
+    let instance = match linker.instantiate(&mut store, &module) {
+        Ok(i) => i,
+        Err(e) => {
+            console_log(
+                &console,
+                ConsoleLevel::Error,
+                format!("[WORKER] instantiate failed: {e}"),
+            );
+            return;
+        }
+    };
+
+    if let Some(guest_mem) = instance.get_memory(&mut store, "memory") {
+        store.data_mut().memory = Some(guest_mem);
+    }
+
+    if let Ok(start_app) = instance.get_typed_func::<(), ()>(&mut store, "start_app") {
+        let _ = store.set_fuel(loader.fuel_limit);
+        if let Err(e) = start_app.call(&mut store, ()) {
+            console_log(
+                &console,
+                ConsoleLevel::Error,
+                format!("[WORKER] start_app trapped: {e}"),
+            );
+            return;
+        }
+    }
+
+    let on_message = instance
+        .get_typed_func::<u32, ()>(&mut store, "on_message")
+        .ok();
+
+    while alive.load(Ordering::Relaxed) {
+        let bytes = match inbox_rx.recv() {
+            Ok(Inbox::Message(b)) => b,
+            Ok(Inbox::Terminate) | Err(_) => break,
+        };
+        let Some(ref on_message) = on_message else {
+            continue;
+        };
+        let len = bytes.len() as u32;
+        *store.data().worker_current_msg.lock().unwrap() = Some(bytes);
+        let _ = store.set_fuel(loader.fuel_limit);
+        if let Err(e) = on_message.call(&mut store, len) {
+            let msg = if e.to_string().contains("fuel") {
+                "[WORKER] on_message fuel limit exceeded".to_string()
+            } else {
+                format!("[WORKER] on_message trapped: {e}")
+            };
+            console_log(&console, ConsoleLevel::Error, msg);
+            break;
+        }
+        *store.data().worker_current_msg.lock().unwrap() = None;
+    }
+}
+
+/// Register all `api_worker_*` / `api_spawn_worker` host functions.
+pub fn register_worker_functions(linker: &mut Linker<HostState>) -> Result<()> {
+    // ── spawn_worker ────────────────────────────────────────────────────────
+    // api_spawn_worker(url_ptr: u32, url_len: u32) -> i32
+    //   Returns a worker handle (> 0), or -1 on error.
+    linker.func_wrap(
+        "oxide",
+        "api_spawn_worker",
+        |caller: Caller<'_, HostState>, url_ptr: u32, url_len: u32| -> i32 {
+            let console = caller.data().console.clone();
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let url = match read_guest_string(&mem, &caller, url_ptr, url_len) {
+                Ok(s) => s,
+                Err(_) => return -1,
+            };
+            let workers = caller.data().workers.clone();
+            ensure_workers(&workers);
+            let id = workers
+                .lock()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .spawn(url.clone(), caller.data());
+            if id == 0 {
+                console_log(
+                    &console,
+                    ConsoleLevel::Error,
+                    "[WORKER] spawn failed (no module loader)".into(),
+                );
+                return -1;
+            }
+            console_log(
+                &console,
+                ConsoleLevel::Log,
+                format!("[WORKER] spawned {url} (handle={id})"),
+            );
+            id as i32
+        },
+    )?;
+
+    // ── worker_post_message ───────────────────────────────────────────────
+    // api_worker_post_message(handle: u32, ptr: u32, len: u32) -> i32
+    //   Parent → worker. Returns 0 on success, -1 if the handle is unknown.
+    linker.func_wrap(
+        "oxide",
+        "api_worker_post_message",
+        |caller: Caller<'_, HostState>, handle: u32, ptr: u32, len: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let data = match read_guest_bytes(&mem, &caller, ptr, len) {
+                Ok(b) => b,
+                Err(_) => return -1,
+            };
+            let workers = caller.data().workers.clone();
+            let g = workers.lock().unwrap();
+            match g.as_ref() {
+                Some(s) if s.post(handle, data) => 0,
+                _ => -1,
+            }
+        },
+    )?;
+
+    // ── worker_recv ─────────────────────────────────────────────────────────
+    // api_worker_recv(handle: u32, out_ptr: u32, out_cap: u32) -> i64
+    //   Worker → parent. -1 if no message is queued, else the byte length written.
+    linker.func_wrap(
+        "oxide",
+        "api_worker_recv",
+        |mut caller: Caller<'_, HostState>, handle: u32, out_ptr: u32, out_cap: u32| -> i64 {
+            let workers = caller.data().workers.clone();
+            let msg = {
+                let g = workers.lock().unwrap();
+                g.as_ref().and_then(|s| s.recv(handle))
+            };
+            let msg = match msg {
+                Some(m) => m,
+                None => return -1,
+            };
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let to_write = if msg.len() > out_cap as usize {
+                &msg[..out_cap as usize]
+            } else {
+                &msg[..]
+            };
+            if write_guest_bytes(&mem, &mut caller, out_ptr, to_write).is_err() {
+                return -1;
+            }
+            to_write.len() as i64
+        },
+    )?;
+
+    // ── worker_terminate ──────────────────────────────────────────────────
+    // api_worker_terminate(handle: u32) -> i32
+    //   Returns 1 if the worker was running, 0 if the handle is unknown.
+    linker.func_wrap(
+        "oxide",
+        "api_worker_terminate",
+        |caller: Caller<'_, HostState>, handle: u32| -> i32 {
+            let workers = caller.data().workers.clone();
+            let mut g = workers.lock().unwrap();
+            let terminated = g.as_mut().map(|s| s.terminate(handle)).unwrap_or(false);
+            i32::from(terminated)
+        },
+    )?;
+
+    // ── worker_post (worker side) ─────────────────────────────────────────
+    // api_worker_post(ptr: u32, len: u32) -> i32
+    //   Worker → its spawning parent. -1 if not running inside a worker.
+    linker.func_wrap(
+        "oxide",
+        "api_worker_post",
+        |caller: Caller<'_, HostState>, ptr: u32, len: u32| -> i32 {
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return -1,
+            };
+            let data = match read_guest_bytes(&mem, &caller, ptr, len) {
+                Ok(b) => b,
+                Err(_) => return -1,
+            };
+            match caller.data().worker_outbox.clone() {
+                Some(outbox) => {
+                    outbox.lock().unwrap().push_back(data);
+                    0
+                }
+                None => -1,
+            }
+        },
+    )?;
+
+    // ── worker_message_read (worker side) ─────────────────────────────────
+    // api_worker_message_read(out_ptr: u32, out_cap: u32) -> u32
+    //   Copies the current inbound message into guest memory during on_message.
+    //   Returns the number of bytes written (0 if no message is active).
+    linker.func_wrap(
+        "oxide",
+        "api_worker_message_read",
+        |mut caller: Caller<'_, HostState>, out_ptr: u32, out_cap: u32| -> u32 {
+            let msg_arc = caller.data().worker_current_msg.clone();
+            let mem = match caller.data().memory {
+                Some(m) => m,
+                None => return 0,
+            };
+            let guard = msg_arc.lock().unwrap();
+            let bytes = match guard.as_ref() {
+                Some(b) => b,
+                None => return 0,
+            };
+            let to_write = if bytes.len() > out_cap as usize {
+                &bytes[..out_cap as usize]
+            } else {
+                &bytes[..]
+            };
+            if write_guest_bytes(&mem, &mut caller, out_ptr, to_write).is_err() {
+                return 0;
+            }
+            to_write.len() as u32
+        },
+    )?;
+
+    Ok(())
+}

--- a/oxide-sdk/src/lib.rs
+++ b/oxide-sdk/src/lib.rs
@@ -933,6 +933,26 @@ extern "C" {
     #[link_name = "api_ws_remove"]
     fn _api_ws_remove(id: u32);
 
+    // ── Background Workers API ──────────────────────────────────────
+
+    #[link_name = "api_spawn_worker"]
+    fn _api_spawn_worker(url_ptr: u32, url_len: u32) -> i32;
+
+    #[link_name = "api_worker_post_message"]
+    fn _api_worker_post_message(handle: u32, ptr: u32, len: u32) -> i32;
+
+    #[link_name = "api_worker_recv"]
+    fn _api_worker_recv(handle: u32, out_ptr: u32, out_cap: u32) -> i64;
+
+    #[link_name = "api_worker_terminate"]
+    fn _api_worker_terminate(handle: u32) -> i32;
+
+    #[link_name = "api_worker_post"]
+    fn _api_worker_post(ptr: u32, len: u32) -> i32;
+
+    #[link_name = "api_worker_message_read"]
+    fn _api_worker_message_read(out_ptr: u32, out_cap: u32) -> u32;
+
     // ── MIDI API ────────────────────────────────────────────────────
 
     #[link_name = "api_midi_input_count"]
@@ -2707,6 +2727,64 @@ pub fn ws_close(id: u32) -> i32 {
 /// leaks.
 pub fn ws_remove(id: u32) {
     unsafe { _api_ws_remove(id) }
+}
+
+// ─── Background Workers API ────────────────────────────────────────────────────
+
+/// Spawn a background worker from a `.wasm` module URL.
+///
+/// The worker runs on its own thread with isolated fuel and linear memory. Its
+/// `start_app()` runs once on spawn; it then receives messages through its
+/// exported `on_message(len: u32)` and replies via [`worker_post`].
+///
+/// `url` may be `http(s)` or `file://`. Use [`url_resolve`] against
+/// [`get_url`] to load a worker module sitting next to the current app.
+///
+/// Returns a handle (`> 0`) on success, or `-1` on error.
+pub fn spawn_worker(url: &str) -> i32 {
+    unsafe { _api_spawn_worker(url.as_ptr() as u32, url.len() as u32) }
+}
+
+/// Send a message to a worker spawned with [`spawn_worker`].
+///
+/// Returns `0` on success, `-1` if the handle is unknown.
+pub fn worker_post_message(handle: u32, data: &[u8]) -> i32 {
+    unsafe { _api_worker_post_message(handle, data.as_ptr() as u32, data.len() as u32) }
+}
+
+/// Poll for one message a worker sent back via [`worker_post`].
+///
+/// Returns the message bytes, or `None` if the worker's outbox is empty.
+pub fn worker_recv(handle: u32) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = unsafe { _api_worker_recv(handle, buf.as_mut_ptr() as u32, buf.len() as u32) };
+    if n < 0 {
+        return None;
+    }
+    buf.truncate(n as usize);
+    Some(buf)
+}
+
+/// Terminate a worker and free its host-side resources.
+///
+/// Returns `1` if the worker was running, `0` if the handle is unknown.
+pub fn worker_terminate(handle: u32) -> i32 {
+    unsafe { _api_worker_terminate(handle) }
+}
+
+/// Send a message from inside a worker back to the parent that spawned it.
+///
+/// Returns `0` on success, `-1` if not running inside a worker.
+pub fn worker_post(data: &[u8]) -> i32 {
+    unsafe { _api_worker_post(data.as_ptr() as u32, data.len() as u32) }
+}
+
+/// Copy the message currently being delivered to `on_message` into `buf`.
+///
+/// Valid only during a worker's `on_message` callback. Returns the number of
+/// bytes written (truncated to `buf.len()`).
+pub fn worker_message_read(buf: &mut [u8]) -> usize {
+    unsafe { _api_worker_message_read(buf.as_mut_ptr() as u32, buf.len() as u32) as usize }
 }
 
 // ─── MIDI API ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…essage passing

Adds a background worker capability so guest apps can offload CPU-heavy work to a separate .wasm module running on its own thread, keeping the frame loop responsive. Workers never share Rust types or linear memory with the parent — communication is pure byte-message passing, consistent with Oxide's airtight-sandbox model.

Host (oxide-browser/src/worker.rs):
- WorkerState registry plus a per-worker thread that fetches (http(s)/file://), compiles, instantiates with its own bounded memory and 500M fuel, runs start_app(), then delivers inbox messages to the worker's on_message export. Reuses the api_load_module instantiation pattern.
- register_worker_functions wires six host imports into register_host_functions:
  - parent side: api_spawn_worker, api_worker_post_message, api_worker_recv, api_worker_terminate
  - worker side: api_worker_post (reply to parent), api_worker_message_read (pull current payload, mirroring the events API)
- HostState gains workers (lazy registry), worker_outbox, and worker_current_msg. Workers share only the persistent KV store and console with their parent; canvas, input, timers, and memory are isolated.

SDK (oxide-sdk/src/lib.rs):
- FFI declarations and documented safe wrappers: spawn_worker, worker_post_message, worker_recv, worker_terminate, worker_post, worker_message_read.

Examples:
- worker-demo: UI that spawns a worker (URL resolved relative to its own module), sends a limit, polls for the result, and animates a spinner to show the main thread never blocks.
- worker-demo-bg: counts primes below the given limit off-thread and posts it back.

Design notes:
- Pull-based delivery (on_message(len) + worker_message_read) avoids requiring a guest allocator and matches the existing events pattern.
- Poll-based replies (worker_recv) mirror ws_recv/fetch_recv idioms.

Checks off the spawn/post/terminate items under Phase 4 (Background Workers) in ROADMAP.md. Opt-in shared memory and worker pools are intentionally left out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background worker support, enabling concurrent task execution with message-based communication between parent and worker threads.
  * Included example applications demonstrating worker spawning and messaging patterns.

* **Documentation**
  * Updated roadmap with worker messaging API specifications.

* **Chores**
  * Extended workspace configuration to include new example projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niklabh/oxide/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->