### PR TITLE
feat(drawing-pad): add interactive drawing pad example with multi-file structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "drawing-pad"
+version = "0.1.0"
+dependencies = [
+ "oxide-sdk",
+]
+
+[[package]]
 name = "dtls"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ members = [
     "examples/shadcn-demo",
     "examples/worker-demo",
     "examples/worker-demo-bg",
+    "examples/drawing-pad",
 ]
 resolver = "2"

--- a/examples/drawing-pad/Cargo.toml
+++ b/examples/drawing-pad/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "drawing-pad"
+version = "0.1.0"
+edition = "2021"
+description = "Interactive drawing pad example for the Oxide browser"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+oxide-sdk = { path = "../../oxide-sdk" }

--- a/examples/drawing-pad/src/app.rs
+++ b/examples/drawing-pad/src/app.rs
@@ -1,0 +1,370 @@
+//! # Application state, entry points, and dock UI
+//!
+//! The global application singleton and the WASM-exported entry points that
+//! the Oxide host calls. The frame loop in `on_frame` orchestrates input,
+//! drawing, and UI each frame, and renders the bottom dock toolbar.
+
+use alloc::vec::Vec;
+
+use oxide_sdk::*;
+
+use crate::geometry::{
+    BUTTON_GAP, BUTTON_HEIGHT, BUTTON_WIDTH, DOCK_BACKGROUND, DOCK_HEIGHT, PALETTE, SWATCH_COLUMNS,
+    SWATCH_HIT_PADDING, SWATCH_SIZE, SWATCH_SPACING,
+};
+use crate::render::render_preview;
+use crate::session::Session;
+use crate::shapes::{DrawTool, Shape};
+
+/// The top-level application state. Holds everything needed to render a frame
+/// and respond to user input.
+struct App {
+    /// Index into `PALETTE` for the currently selected drawing color.
+    selected_color_index: usize,
+    /// Current brush/stroke thickness in pixels. Adjustable via the dock slider.
+    brush_size: f32,
+    /// The currently active drawing tool (Line, Rect, Circle, or Freehand).
+    active_tool: DrawTool,
+    /// The current drawing session state machine. `Idle` when no stroke is active,
+    /// `Drawing` while the user is actively drawing.
+    session: Session,
+    /// Tracks the previous frame's mouse-button state for edge detection.
+    /// `just_pressed` is true only on the frame when the button transitions
+    /// from up to down (not while it's held).
+    was_mouse_down: bool,
+    /// All shapes that have been committed (finished drawing strokes). These are
+    /// re-rendered every frame in order, forming the drawing's history.
+    committed_shapes: Vec<Shape>,
+}
+
+/// Global application singleton stored as a `static mut`. This is safe because:
+///
+/// - The WASM guest is single-threaded (no concurrent access).
+/// - `on_frame` is the only entry point that touches `APP`, and it never holds
+///   two borrows simultaneously (the scoped borrow block ensures this).
+/// - `start_app` only calls `log()`, which doesn't touch `APP`.
+static mut APP: Option<App> = None;
+
+/// Get mutable access to the global app state. Initializes `APP` on first call
+/// with default values (green color, 6px brush, Line tool, empty canvas).
+///
+/// # Safety
+///
+/// The WASM guest is single-threaded and `on_frame` is the only entry point
+/// that touches `APP`. Callers must not hold two borrows simultaneously —
+/// the scoped borrow block in [`on_frame`] (the Input phase) ensures this by
+/// dropping the borrow before any button callbacks can re-borrow.
+fn app() -> &'static mut App {
+    unsafe {
+        APP.get_or_insert(App {
+            selected_color_index: 3, // Default: Green (index 3 in PALETTE)
+            brush_size: 6.0,
+            active_tool: DrawTool::Line,
+            session: Session::Idle,
+            was_mouse_down: false,
+            committed_shapes: Vec::new(),
+        })
+    }
+}
+
+/// WASM-exported entry point called once when the module is loaded by the host.
+/// Logs a startup message to the browser console.
+#[no_mangle]
+pub extern "C" fn start_app() {
+    log("Drawing pad started");
+}
+
+/// WASM-exported frame loop, called by the Oxide host every frame (~60 Hz).
+/// `delta_ms` is the time in milliseconds since the last frame (currently unused
+/// but available for animation timing).
+///
+/// Each frame executes three phases:
+///
+/// ## 1. Input
+///
+/// A scoped borrow of `app()` handles all input processing. The scope is critical:
+/// it drops the mutable borrow before any `ui_button_variant` callbacks execute,
+/// preventing double-mutable-borrow panics (buttons re-borrow `app()` in their
+/// closures).
+///
+/// Input handling:
+/// - **Mouse press on swatch** → Update selected color.
+/// - **Mouse press on canvas** → Start a new `Session::Drawing`.
+/// - **Mouse held** → Push mouse position into the active session.
+/// - **Mouse release** → Finish the session, commit the resulting Shape.
+///
+/// ## 2. Draw
+///
+/// Clear the canvas to the dark background color, render all committed shapes,
+/// and render the live preview of the in-progress stroke (if any).
+///
+/// ## 3. Dock
+///
+/// Render the bottom toolbar:
+/// - Dark background rect.
+/// - Clear button (✕) — clears all committed shapes.
+/// - Tool mode buttons — stacked vertically on the left; active tool is highlighted.
+/// - Brush size slider — horizontal bar between tools and palette.
+/// - Color swatches — 4×3 grid centered in the dock; selected color has a glow.
+#[no_mangle]
+pub extern "C" fn on_frame(_delta_ms: u32) {
+    let (canvas_width, canvas_height) = canvas_dimensions();
+    let (canvas_width, canvas_height) = (canvas_width as f32, canvas_height as f32);
+    let dock_top = canvas_height - DOCK_HEIGHT;
+    let (mouse_x, mouse_y) = mouse_position();
+    let mouse_is_down = mouse_button_down(0);
+
+    // ── Input ──────────────────────────────────────────────────────────
+    // Scoped borrow: release `app` before button callbacks run so they
+    // can re-borrow freely without a double-mutable-borrow conflict.
+    //
+    // This scope is necessary because `ui_button_variant` closures capture
+    // `app()` mutably, and the outer `app()` borrow above would conflict.
+    // By confining the borrow to this block, it's dropped before any
+    // callback executes.
+    {
+        let app = app();
+        // Detect the leading edge of a mouse press (down this frame, was up last frame).
+        // This prevents repeated actions from held buttons (e.g., starting a new stroke
+        // every frame while the mouse is held).
+        let just_pressed = mouse_is_down && !app.was_mouse_down;
+        let (swatch_origin_x, swatch_origin_y) = compute_swatch_origin(canvas_width, dock_top);
+        if just_pressed {
+            // Check if the click landed on a color swatch.
+            if let Some(color_index) =
+                hit_test_swatches(mouse_x, mouse_y, swatch_origin_x, swatch_origin_y)
+            {
+                app.selected_color_index = color_index;
+            }
+        }
+        // Only start a new stroke if:
+        //   - This is a leading-edge press (just pressed, not held)
+        //   - The click is on the canvas area (above the dock, with a 4px margin)
+        //   - No stroke is currently active (session is Idle)
+        let in_canvas_area = mouse_y > 0.0 && mouse_y < dock_top - 4.0;
+        if just_pressed && in_canvas_area && matches!(app.session, Session::Idle) {
+            app.session = Session::begin(
+                app.active_tool,
+                PALETTE[app.selected_color_index],
+                app.brush_size,
+                (mouse_x, mouse_y),
+            );
+        }
+        // While the mouse is held, feed the current position into the active session.
+        if mouse_is_down {
+            app.session.push((mouse_x, mouse_y));
+        }
+        // On mouse release: finish the session and commit the resulting shape.
+        if !mouse_is_down && app.was_mouse_down {
+            // `mem::replace` moves the session out so we can call `finish()` (which
+            // consumes self) while simultaneously setting the session back to Idle.
+            let previous_session = core::mem::replace(&mut app.session, Session::Idle);
+            if let Some(shape) = previous_session.finish() {
+                app.committed_shapes.push(shape);
+            }
+        }
+        // Record mouse state for edge detection in the next frame.
+        app.was_mouse_down = mouse_is_down;
+    }
+
+    // ── Draw ───────────────────────────────────────────────────────────
+    // Clear the entire canvas to a dark blue-gray background.
+    canvas_clear(30, 30, 46, 255);
+    // Re-render every committed shape from oldest to newest (painter's algorithm).
+    for shape in &app().committed_shapes {
+        shape.render();
+    }
+    // Render the live preview of the in-progress stroke (rubber-banding for
+    // geometric tools, accumulating polyline for freehand).
+    if let Session::Drawing {
+        tool,
+        color,
+        thickness,
+        start,
+        ref points,
+        ..
+    } = app().session
+    {
+        let end = *points.last().unwrap_or(&start);
+        render_preview(tool, start, end, points, color, thickness);
+    }
+
+    // ── Dock ───────────────────────────────────────────────────────────
+    // Draw the dock background as a filled rectangle spanning the full width.
+    canvas_rect(
+        0.0,
+        dock_top,
+        canvas_width,
+        DOCK_HEIGHT,
+        DOCK_BACKGROUND.0,
+        DOCK_BACKGROUND.1,
+        DOCK_BACKGROUND.2,
+        255,
+    );
+
+    let (grid_x, grid_y) = compute_swatch_origin(canvas_width, dock_top);
+    // Position the clear button to the right of the swatch grid.
+    let clear_x = grid_x + SWATCH_COLUMNS as f32 * SWATCH_SPACING + 20.0;
+    let clear_y = dock_top + (DOCK_HEIGHT - 32.0) / 2.0;
+
+    // Clear button — Ghost variant (transparent until hover), ✕ symbol.
+    ui_button_variant(
+        2,
+        clear_x,
+        clear_y,
+        32.0,
+        32.0,
+        "✕",
+        UiVariant::Ghost,
+        || {
+            app().committed_shapes.clear();
+        },
+    );
+
+    // Tool mode buttons — stacked vertically on the left side of the dock.
+    // Vertically centered within the dock height based on the number of tools.
+    let mode_button_top_y = dock_top
+        + (DOCK_HEIGHT - DrawTool::ALL.len() as f32 * (BUTTON_HEIGHT + BUTTON_GAP) - BUTTON_GAP)
+            / 2.0;
+    for (tool_index, &tool) in DrawTool::ALL.iter().enumerate() {
+        // The active tool gets the Default (filled) variant; others are Ghost.
+        let variant = if app().active_tool == tool {
+            UiVariant::Default
+        } else {
+            UiVariant::Ghost
+        };
+        let button_y = mode_button_top_y + tool_index as f32 * (BUTTON_HEIGHT + BUTTON_GAP);
+        ui_button_variant(
+            10 + tool_index as u32,
+            16.0,
+            button_y,
+            BUTTON_WIDTH,
+            BUTTON_HEIGHT,
+            tool.label(),
+            variant,
+            move || {
+                app().active_tool = tool;
+            },
+        );
+    }
+
+    // Brush size slider — horizontal bar positioned between the tool buttons
+    // and the color swatch grid. Returns the current slider value, which is
+    // immediately applied to `app().brush_size`.
+    let brush_x = grid_x - 20.0 - 108.0;
+    let brush_y = dock_top + (DOCK_HEIGHT - 22.0) / 2.0;
+    let brush = ui_slider(5, brush_x, brush_y, 88.0, 1.0, 40.0, 6.0);
+    app().brush_size = brush;
+    // Display the current brush size as text below the slider.
+    canvas_text(
+        brush_x,
+        brush_y + 26.0,
+        12.0,
+        220,
+        220,
+        230,
+        255,
+        &format!("{:.0}px", brush),
+    );
+
+    // Color swatches — render the 4×3 grid of palette colors. The selected
+    // swatch gets an additional semi-transparent glow (rounded rect behind it)
+    // at 60% opacity to indicate selection.
+    let (sel_red, sel_green, sel_blue) = PALETTE[app().selected_color_index];
+    for (palette_idx, &(swatch_red, swatch_green, swatch_blue)) in PALETTE.iter().enumerate() {
+        let (swatch_x, swatch_y) = swatch_cell(palette_idx, grid_x, grid_y);
+        // Selection indicator: a slightly larger, semi-transparent rounded rect
+        // behind the selected swatch, creating a subtle glow effect.
+        if palette_idx == app().selected_color_index {
+            canvas_rounded_rect(
+                swatch_x - 2.0,
+                swatch_y - 2.0,
+                SWATCH_SIZE + 4.0,
+                SWATCH_SIZE + 4.0,
+                6.0,
+                sel_red,
+                sel_green,
+                sel_blue,
+                60,
+            );
+        }
+        // The swatch itself — a fully opaque rounded rectangle.
+        canvas_rounded_rect(
+            swatch_x,
+            swatch_y,
+            SWATCH_SIZE,
+            SWATCH_SIZE,
+            5.0,
+            swatch_red,
+            swatch_green,
+            swatch_blue,
+            255,
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  Layout helpers
+//
+//  Utility functions for computing positions within the dock's swatch grid.
+//  The palette is arranged as a 4-column × 3-row grid, centered horizontally
+//  in the dock and positioned near the bottom with a 12px margin.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Compute the (x, y) position of a swatch cell given its palette index and the
+/// grid's origin point.
+///
+/// The grid is laid out in row-major order:
+///   - Column = index % SWATCH_COLUMNS (wraps every 4)
+///   - Row = index / SWATCH_COLUMNS (integer division)
+///
+/// Position = origin + (column × spacing, row × spacing)
+fn swatch_cell(index: usize, grid_origin_x: f32, grid_origin_y: f32) -> (f32, f32) {
+    (
+        grid_origin_x + (index as u32 % SWATCH_COLUMNS) as f32 * SWATCH_SPACING,
+        grid_origin_y + (index as u32 / SWATCH_COLUMNS) as f32 * SWATCH_SPACING,
+    )
+}
+
+/// Compute the top-left origin of the swatch grid, centering it horizontally
+/// in the canvas and positioning it near the bottom of the dock.
+///
+/// Horizontal: `(canvas_width - grid_width) / 2.0` centers the grid.
+/// Vertical: `dock_top + DOCK_HEIGHT - grid_height - 12.0` places the grid
+///   near the bottom of the dock with a 12px bottom margin.
+fn compute_swatch_origin(canvas_width: f32, dock_top: f32) -> (f32, f32) {
+    let grid_width = SWATCH_COLUMNS as f32 * SWATCH_SPACING;
+    let grid_height = (PALETTE.len() as u32 / SWATCH_COLUMNS) as f32 * SWATCH_SPACING;
+    (
+        (canvas_width - grid_width) / 2.0,
+        dock_top + DOCK_HEIGHT - grid_height - 12.0,
+    )
+}
+
+/// Hit-test the mouse position against all swatches in the palette grid.
+/// Returns the index of the first swatch whose bounding box (expanded by
+/// `SWATCH_HIT_PADDING` on all sides) contains the mouse position.
+///
+/// The padding makes swatches easier to click by extending the clickable area
+/// beyond the visible swatch square. Uses `find_map` to short-circuit on the
+/// first match (swatches don't overlap, so at most one can match).
+fn hit_test_swatches(
+    mouse_x: f32,
+    mouse_y: f32,
+    grid_origin_x: f32,
+    grid_origin_y: f32,
+) -> Option<usize> {
+    PALETTE.iter().enumerate().find_map(|(palette_idx, _)| {
+        let (swatch_x, swatch_y) = swatch_cell(palette_idx, grid_origin_x, grid_origin_y);
+        // AABB (axis-aligned bounding box) test with padding.
+        if mouse_x >= swatch_x - SWATCH_HIT_PADDING
+            && mouse_x <= swatch_x + SWATCH_SIZE + SWATCH_HIT_PADDING
+            && mouse_y >= swatch_y - SWATCH_HIT_PADDING
+            && mouse_y <= swatch_y + SWATCH_SIZE + SWATCH_HIT_PADDING
+        {
+            Some(palette_idx)
+        } else {
+            None
+        }
+    })
+}

--- a/examples/drawing-pad/src/app.rs
+++ b/examples/drawing-pad/src/app.rs
@@ -115,32 +115,17 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
     let mouse_is_down = mouse_button_down(0);
 
     // ── Input ──────────────────────────────────────────────────────────
-    // Scoped borrow: release `app` before button callbacks run so they
-    // can re-borrow freely without a double-mutable-borrow conflict.
-    //
-    // This scope is necessary because `ui_button_variant` closures capture
-    // `app()` mutably, and the outer `app()` borrow above would conflict.
-    // By confining the borrow to this block, it's dropped before any
-    // callback executes.
     {
         let app = app();
-        // Detect the leading edge of a mouse press (down this frame, was up last frame).
-        // This prevents repeated actions from held buttons (e.g., starting a new stroke
-        // every frame while the mouse is held).
         let just_pressed = mouse_is_down && !app.was_mouse_down;
         let (swatch_origin_x, swatch_origin_y) = compute_swatch_origin(canvas_width, dock_top);
         if just_pressed {
-            // Check if the click landed on a color swatch.
             if let Some(color_index) =
                 hit_test_swatches(mouse_x, mouse_y, swatch_origin_x, swatch_origin_y)
             {
                 app.selected_color_index = color_index;
             }
         }
-        // Only start a new stroke if:
-        //   - This is a leading-edge press (just pressed, not held)
-        //   - The click is on the canvas area (above the dock, with a 4px margin)
-        //   - No stroke is currently active (session is Idle)
         let in_canvas_area = mouse_y > 0.0 && mouse_y < dock_top - 4.0;
         if just_pressed && in_canvas_area && matches!(app.session, Session::Idle) {
             app.session = Session::begin(
@@ -150,32 +135,23 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
                 (mouse_x, mouse_y),
             );
         }
-        // While the mouse is held, feed the current position into the active session.
         if mouse_is_down {
             app.session.push((mouse_x, mouse_y));
         }
-        // On mouse release: finish the session and commit the resulting shape.
         if !mouse_is_down && app.was_mouse_down {
-            // `mem::replace` moves the session out so we can call `finish()` (which
-            // consumes self) while simultaneously setting the session back to Idle.
             let previous_session = core::mem::replace(&mut app.session, Session::Idle);
             if let Some(shape) = previous_session.finish() {
                 app.committed_shapes.push(shape);
             }
         }
-        // Record mouse state for edge detection in the next frame.
         app.was_mouse_down = mouse_is_down;
     }
 
     // ── Draw ───────────────────────────────────────────────────────────
-    // Clear the entire canvas to a dark blue-gray background.
     canvas_clear(30, 30, 46, 255);
-    // Re-render every committed shape from oldest to newest (painter's algorithm).
     for shape in &app().committed_shapes {
         shape.render();
     }
-    // Render the live preview of the in-progress stroke (rubber-banding for
-    // geometric tools, accumulating polyline for freehand).
     if let Session::Drawing {
         tool,
         color,
@@ -190,7 +166,6 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
     }
 
     // ── Dock ───────────────────────────────────────────────────────────
-    // Draw the dock background as a filled rectangle spanning the full width.
     canvas_rect(
         0.0,
         dock_top,
@@ -203,11 +178,9 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
     );
 
     let (grid_x, grid_y) = compute_swatch_origin(canvas_width, dock_top);
-    // Position the clear button to the right of the swatch grid.
     let clear_x = grid_x + SWATCH_COLUMNS as f32 * SWATCH_SPACING + 20.0;
     let clear_y = dock_top + (DOCK_HEIGHT - 32.0) / 2.0;
 
-    // Clear button — Ghost variant (transparent until hover), ✕ symbol.
     ui_button_variant(
         2,
         clear_x,
@@ -221,13 +194,10 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
         },
     );
 
-    // Tool mode buttons — stacked vertically on the left side of the dock.
-    // Vertically centered within the dock height based on the number of tools.
     let mode_button_top_y = dock_top
         + (DOCK_HEIGHT - DrawTool::ALL.len() as f32 * (BUTTON_HEIGHT + BUTTON_GAP) - BUTTON_GAP)
             / 2.0;
     for (tool_index, &tool) in DrawTool::ALL.iter().enumerate() {
-        // The active tool gets the Default (filled) variant; others are Ghost.
         let variant = if app().active_tool == tool {
             UiVariant::Default
         } else {
@@ -248,14 +218,10 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
         );
     }
 
-    // Brush size slider — horizontal bar positioned between the tool buttons
-    // and the color swatch grid. Returns the current slider value, which is
-    // immediately applied to `app().brush_size`.
     let brush_x = grid_x - 20.0 - 108.0;
     let brush_y = dock_top + (DOCK_HEIGHT - 22.0) / 2.0;
     let brush = ui_slider(5, brush_x, brush_y, 88.0, 1.0, 40.0, 6.0);
     app().brush_size = brush;
-    // Display the current brush size as text below the slider.
     canvas_text(
         brush_x,
         brush_y + 26.0,
@@ -267,14 +233,9 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
         &format!("{:.0}px", brush),
     );
 
-    // Color swatches — render the 4×3 grid of palette colors. The selected
-    // swatch gets an additional semi-transparent glow (rounded rect behind it)
-    // at 60% opacity to indicate selection.
     let (sel_red, sel_green, sel_blue) = PALETTE[app().selected_color_index];
     for (palette_idx, &(swatch_red, swatch_green, swatch_blue)) in PALETTE.iter().enumerate() {
         let (swatch_x, swatch_y) = swatch_cell(palette_idx, grid_x, grid_y);
-        // Selection indicator: a slightly larger, semi-transparent rounded rect
-        // behind the selected swatch, creating a subtle glow effect.
         if palette_idx == app().selected_color_index {
             canvas_rounded_rect(
                 swatch_x - 2.0,
@@ -288,7 +249,6 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
                 60,
             );
         }
-        // The swatch itself — a fully opaque rounded rectangle.
         canvas_rounded_rect(
             swatch_x,
             swatch_y,
@@ -303,13 +263,7 @@ pub extern "C" fn on_frame(_delta_ms: u32) {
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-//  Layout helpers
-//
-//  Utility functions for computing positions within the dock's swatch grid.
-//  The palette is arranged as a 4-column × 3-row grid, centered horizontally
-//  in the dock and positioned near the bottom with a 12px margin.
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── Layout helpers ───────────────────────────────────────────────────────
 
 /// Compute the (x, y) position of a swatch cell given its palette index and the
 /// grid's origin point.

--- a/examples/drawing-pad/src/geometry.rs
+++ b/examples/drawing-pad/src/geometry.rs
@@ -1,0 +1,78 @@
+//! # Geometry — core types, palette, and layout constants
+//!
+//! Fundamental data types and constants shared across the entire application:
+//! the `Point`/`Color` type aliases, the Euclidean `dist()` helper, the 12-color
+//! `PALETTE`, and every layout constant that sizes and positions the dock UI.
+
+/// A 2D point in canvas coordinates (x, y), measured in pixels from the top-left origin.
+/// Used for all geometry: stroke vertices, shape anchors, UI hit testing, and layout.
+pub(crate) type Point = (f32, f32);
+
+/// An RGB color triplet with 8-bit channels (0–255 per channel).
+/// Alpha is always 255 (fully opaque) unless explicitly specified at the call site.
+pub(crate) type Color = (u8, u8, u8);
+
+/// Compute the Euclidean distance between two points using the Pythagorean theorem:
+///   dist = √((x₂ - x₁)² + (y₂ - y₁)²)
+///
+/// Used throughout for hit testing (swatch clicks, circle closing distance), shape
+/// recognition (radius consistency checks), and geometry construction (circle radius
+/// from center to cursor).
+pub(crate) fn dist(point_a: Point, point_b: Point) -> f32 {
+    let (delta_x, delta_y) = (point_a.0 - point_b.0, point_a.1 - point_b.1);
+    (delta_x * delta_x + delta_y * delta_y).sqrt()
+}
+
+/// The 12-color palette available to the user, arranged in a 4×3 grid in the dock.
+/// Colors are chosen for high contrast against the dark canvas background (RGB 30,30,46).
+///
+/// Layout in the grid (left-to-right, top-to-bottom):
+///   Row 0: Slate(30,41,59)   Red(239,68,68)     Blue(59,130,246)    Green(52,211,153)
+///   Row 1: Amber(251,191,36) Pink(244,114,182)  Purple(139,92,246)  Cyan(34,211,238)
+///   Row 2: White(241,245,249) Gray(100,116,139) Brown(180,83,9)     Emerald(4,120,87)
+pub(crate) const PALETTE: [Color; 12] = [
+    (30, 41, 59),    // Slate — near-black, subtle on dark bg
+    (239, 68, 68),   // Red — vivid primary
+    (59, 130, 246),  // Blue — vivid primary
+    (52, 211, 153),  // Green — teal/emerald tone
+    (251, 191, 36),  // Amber — warm yellow
+    (244, 114, 182), // Pink — soft magenta
+    (139, 92, 246),  // Purple — violet
+    (34, 211, 238),  // Cyan — bright aqua
+    (241, 245, 249), // White — near-white, for highlights
+    (100, 116, 139), // Gray — muted neutral
+    (180, 83, 9),    // Brown — earthy dark orange
+    (4, 120, 87),    // Emerald — deep green
+];
+
+/// Number of columns in the color swatch grid. The 12 colors are laid out in a
+/// 4-column × 3-row grid centered horizontally in the dock.
+pub(crate) const SWATCH_COLUMNS: u32 = 4;
+
+/// Width and height of each color swatch square in pixels.
+pub(crate) const SWATCH_SIZE: f32 = 28.0;
+
+/// Center-to-center spacing between adjacent swatch cells (both horizontal and vertical).
+/// Must be > SWATCH_SIZE to leave visual gaps between swatches.
+pub(crate) const SWATCH_SPACING: f32 = 32.0;
+
+/// Extra padding added around each swatch's bounding box for hit testing. This makes
+/// swatches easier to click by extending the clickable area beyond the visible square.
+pub(crate) const SWATCH_HIT_PADDING: f32 = 4.0;
+
+/// Width of the tool mode buttons (Line, Rect, Circle, Freehand) in the dock.
+pub(crate) const BUTTON_WIDTH: f32 = 64.0;
+
+/// Height of each tool mode button.
+pub(crate) const BUTTON_HEIGHT: f32 = 22.0;
+
+/// Vertical gap between stacked tool mode buttons.
+pub(crate) const BUTTON_GAP: f32 = 4.0;
+
+/// Total height of the bottom dock panel in pixels. The dock occupies the bottom
+/// DOCK_HEIGHT pixels of the canvas; everything above is the drawing area.
+pub(crate) const DOCK_HEIGHT: f32 = 120.0;
+
+/// Background color of the dock — a very dark blue-gray that contrasts with both
+/// the canvas background (30,30,46) and the UI elements rendered on top.
+pub(crate) const DOCK_BACKGROUND: Color = (24, 24, 34);

--- a/examples/drawing-pad/src/geometry.rs
+++ b/examples/drawing-pad/src/geometry.rs
@@ -4,12 +4,10 @@
 //! the `Point`/`Color` type aliases, the Euclidean `dist()` helper, the 12-color
 //! `PALETTE`, and every layout constant that sizes and positions the dock UI.
 
-/// A 2D point in canvas coordinates (x, y), measured in pixels from the top-left origin.
-/// Used for all geometry: stroke vertices, shape anchors, UI hit testing, and layout.
+/// A 2D point in canvas coordinates (x, y).
 pub(crate) type Point = (f32, f32);
 
-/// An RGB color triplet with 8-bit channels (0–255 per channel).
-/// Alpha is always 255 (fully opaque) unless explicitly specified at the call site.
+/// An RGB color triplet with 8-bit channels.
 pub(crate) type Color = (u8, u8, u8);
 
 /// Compute the Euclidean distance between two points using the Pythagorean theorem:
@@ -45,34 +43,12 @@ pub(crate) const PALETTE: [Color; 12] = [
     (4, 120, 87),    // Emerald — deep green
 ];
 
-/// Number of columns in the color swatch grid. The 12 colors are laid out in a
-/// 4-column × 3-row grid centered horizontally in the dock.
 pub(crate) const SWATCH_COLUMNS: u32 = 4;
-
-/// Width and height of each color swatch square in pixels.
 pub(crate) const SWATCH_SIZE: f32 = 28.0;
-
-/// Center-to-center spacing between adjacent swatch cells (both horizontal and vertical).
-/// Must be > SWATCH_SIZE to leave visual gaps between swatches.
 pub(crate) const SWATCH_SPACING: f32 = 32.0;
-
-/// Extra padding added around each swatch's bounding box for hit testing. This makes
-/// swatches easier to click by extending the clickable area beyond the visible square.
 pub(crate) const SWATCH_HIT_PADDING: f32 = 4.0;
-
-/// Width of the tool mode buttons (Line, Rect, Circle, Freehand) in the dock.
 pub(crate) const BUTTON_WIDTH: f32 = 64.0;
-
-/// Height of each tool mode button.
 pub(crate) const BUTTON_HEIGHT: f32 = 22.0;
-
-/// Vertical gap between stacked tool mode buttons.
 pub(crate) const BUTTON_GAP: f32 = 4.0;
-
-/// Total height of the bottom dock panel in pixels. The dock occupies the bottom
-/// DOCK_HEIGHT pixels of the canvas; everything above is the drawing area.
 pub(crate) const DOCK_HEIGHT: f32 = 120.0;
-
-/// Background color of the dock — a very dark blue-gray that contrasts with both
-/// the canvas background (30,30,46) and the UI elements rendered on top.
 pub(crate) const DOCK_BACKGROUND: Color = (24, 24, 34);

--- a/examples/drawing-pad/src/lib.rs
+++ b/examples/drawing-pad/src/lib.rs
@@ -1,0 +1,33 @@
+//! # Drawing Pad — Oxide Browser Example
+//!
+//! An interactive drawing application that runs as a WASM guest inside the Oxide
+//! browser. Supports freehand drawing with automatic circle recognition, plus
+//! line, rectangle, and circle tools, with a bottom dock for color, brush size,
+//! and tool selection.
+//!
+//! ## Module layout
+//!
+//! - [`geometry`] — core types, the color palette, and dock layout constants.
+//! - [`smoothing`] — multi-stage stroke-smoothing and circle-recognition pipeline.
+//! - [`shapes`] — drawing tools (`DrawTool`) and committed geometry (`Geom`, `Shape`).
+//! - [`session`] — the drawing-session state machine (idle → drawing → committed shape).
+//! - [`render`] — low-level canvas helpers (rect outlines, stroke tubes, previews).
+//! - [`app`] — global state, the WASM entry points (`start_app`/`on_frame`), dock UI.
+//!
+//! ## Architecture
+//!
+//! This is a single-threaded frame loop driven by the Oxide host. The host calls
+//! `on_frame(delta_ms)` every frame (~60 Hz), and each frame runs three phases:
+//! input, draw, and dock UI. All drawing and UI happens through the `oxide-sdk`
+//! FFI boundary — canvas primitives, mouse input, UI widgets, and logging.
+
+#![allow(static_mut_refs)]
+
+extern crate alloc;
+
+mod app;
+mod geometry;
+mod render;
+mod session;
+mod shapes;
+mod smoothing;

--- a/examples/drawing-pad/src/render.rs
+++ b/examples/drawing-pad/src/render.rs
@@ -1,0 +1,163 @@
+//! # Rendering
+//!
+//! Low-level drawing functions that convert shapes and strokes into canvas
+//! primitive calls. These handle the visual details that the geometry types
+//! don't encode directly (e.g., rectangle outlines as 4 lines, freehand
+//! strokes as thick polylines with round joints).
+
+use oxide_sdk::*;
+
+use crate::geometry::{dist, Color, Point};
+use crate::shapes::DrawTool;
+
+/// Render a rectangle outline: a semi-transparent filled interior plus four
+/// solid edge lines.
+///
+/// The interior is drawn with α=60 (about 24% opacity) using `canvas_rect`,
+/// giving a subtle fill that doesn't overpower the stroke. The four edges are
+/// drawn as individual `canvas_line` calls with full opacity (α=255) and the
+/// specified thickness.
+///
+/// The corners are formed by iterating over the 5 corner points in order:
+///   (left,top) → (right,top) → (right,bottom) → (left,bottom) → (left,top)
+/// and drawing lines between consecutive pairs via `windows(2)`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn draw_rect_outline(
+    left: f32,
+    top: f32,
+    right: f32,
+    bottom: f32,
+    red: u8,
+    green: u8,
+    blue: u8,
+    thickness: f32,
+) {
+    // Semi-transparent fill for the rectangle interior.
+    canvas_rect(left, top, right - left, bottom - top, red, green, blue, 60);
+    // Draw the 4 edges as thick lines connecting consecutive corners.
+    for window in [
+        (left, top),
+        (right, top),
+        (right, bottom),
+        (left, bottom),
+        (left, top), // Closes the rectangle by returning to the start.
+    ]
+    .windows(2)
+    {
+        canvas_line(
+            window[0].0,
+            window[0].1,
+            window[1].0,
+            window[1].1,
+            red,
+            green,
+            blue,
+            255,
+            thickness,
+        );
+    }
+}
+
+/// Render a freehand stroke as a "tube" — a series of connected thick line segments
+/// with filled circles at each joint for smooth, rounded connections.
+///
+/// This technique prevents visible gaps or sharp angles at the joints between
+/// consecutive line segments. Without the joint circles, two thick lines meeting
+/// at an angle would leave a triangular gap at the corner.
+///
+/// Rendering steps:
+///   1. Draw thick `canvas_line` segments between each consecutive pair of points.
+///   2. Draw a filled `canvas_circle` at each point with radius = thickness × 0.5.
+///
+/// Special cases:
+///   - Empty point list: no-op.
+///   - Single point: renders as just a circle (a dot).
+pub(crate) fn render_stroke_tube(points: &[Point], color: Color, thickness: f32) {
+    if points.is_empty() {
+        return;
+    }
+    let (red, green, blue) = color;
+    let joint_radius = thickness * 0.5;
+    if points.len() == 1 {
+        // Single point — render as a dot (filled circle).
+        canvas_circle(
+            points[0].0,
+            points[0].1,
+            joint_radius,
+            red,
+            green,
+            blue,
+            255,
+        );
+        return;
+    }
+    // Draw thick line segments between consecutive points.
+    for segment in points.windows(2) {
+        canvas_line(
+            segment[0].0,
+            segment[0].1,
+            segment[1].0,
+            segment[1].1,
+            red,
+            green,
+            blue,
+            255,
+            thickness,
+        );
+    }
+    // Draw filled circles at each joint to fill gaps at corners.
+    for &point in points {
+        canvas_circle(point.0, point.1, joint_radius, red, green, blue, 255);
+    }
+}
+
+/// Render a live preview of an in-progress stroke. This is called every frame
+/// while the user is actively drawing, providing immediate visual feedback.
+///
+/// Mirrors the rendering logic of [`crate::shapes::Shape::render`] but uses the
+/// current mouse position (`end`) as the endpoint rather than the committed end
+/// position.
+///
+/// For geometric tools (Line, Rect, Circle), the endpoint follows the mouse in
+/// real time, so the user sees the shape "rubber-band" as they drag. For Freehand,
+/// the accumulated `points` array is rendered directly using the tube renderer.
+pub(crate) fn render_preview(
+    tool: DrawTool,
+    start: Point,
+    end: Point,
+    points: &[Point],
+    color: Color,
+    thickness: f32,
+) {
+    let (red, green, blue) = color;
+    match tool {
+        DrawTool::Line => {
+            canvas_line(
+                start.0, start.1, end.0, end.1, red, green, blue, 255, thickness,
+            );
+        }
+        DrawTool::Circle => {
+            let radius = dist(start, end);
+            canvas_arc(
+                start.0,
+                start.1,
+                radius,
+                0.0,
+                core::f32::consts::TAU,
+                red,
+                green,
+                blue,
+                255,
+                thickness,
+            );
+        }
+        DrawTool::Rect => {
+            let left = start.0.min(end.0);
+            let right = start.0.max(end.0);
+            let top = start.1.min(end.1);
+            let bottom = start.1.max(end.1);
+            draw_rect_outline(left, top, right, bottom, red, green, blue, thickness);
+        }
+        DrawTool::Freehand => render_stroke_tube(points, color, thickness),
+    }
+}

--- a/examples/drawing-pad/src/render.rs
+++ b/examples/drawing-pad/src/render.rs
@@ -32,15 +32,13 @@ pub(crate) fn draw_rect_outline(
     blue: u8,
     thickness: f32,
 ) {
-    // Semi-transparent fill for the rectangle interior.
     canvas_rect(left, top, right - left, bottom - top, red, green, blue, 60);
-    // Draw the 4 edges as thick lines connecting consecutive corners.
     for window in [
         (left, top),
         (right, top),
         (right, bottom),
         (left, bottom),
-        (left, top), // Closes the rectangle by returning to the start.
+        (left, top),
     ]
     .windows(2)
     {
@@ -79,7 +77,6 @@ pub(crate) fn render_stroke_tube(points: &[Point], color: Color, thickness: f32)
     let (red, green, blue) = color;
     let joint_radius = thickness * 0.5;
     if points.len() == 1 {
-        // Single point — render as a dot (filled circle).
         canvas_circle(
             points[0].0,
             points[0].1,
@@ -91,7 +88,6 @@ pub(crate) fn render_stroke_tube(points: &[Point], color: Color, thickness: f32)
         );
         return;
     }
-    // Draw thick line segments between consecutive points.
     for segment in points.windows(2) {
         canvas_line(
             segment[0].0,
@@ -105,7 +101,6 @@ pub(crate) fn render_stroke_tube(points: &[Point], color: Color, thickness: f32)
             thickness,
         );
     }
-    // Draw filled circles at each joint to fill gaps at corners.
     for &point in points {
         canvas_circle(point.0, point.1, joint_radius, red, green, blue, 255);
     }

--- a/examples/drawing-pad/src/session.rs
+++ b/examples/drawing-pad/src/session.rs
@@ -45,9 +45,7 @@ pub(crate) enum Session {
 }
 
 impl Session {
-    /// Begin a new drawing session at the given position. The first point is
-    /// immediately added to the point list. The initial `average_step_distance`
-    /// of 4.0 provides a reasonable starting threshold for the adaptive sampler.
+    /// Begin a new drawing session at the given position.
     pub(crate) fn begin(tool: DrawTool, color: Color, thickness: f32, start: Point) -> Self {
         Self::Drawing {
             tool,
@@ -83,26 +81,19 @@ impl Session {
             let distance = points
                 .last()
                 .map_or(f32::INFINITY, |&last| dist(point, last));
-            // Exponential moving average update: blends old average with new sample.
             *average_step_distance = *average_step_distance * 0.7 + distance * 0.3;
-            // Accept only if the point moves meaningfully relative to recent speed.
             if distance >= (*average_step_distance * 0.8).clamp(2.0, 10.0) {
                 points.push(point);
             }
         }
     }
 
-    /// Finish the current stroke and produce a committed Shape. Consumes the session
-    /// (moves it out of `App::session` via `mem::replace` in the Input phase of
-    /// [`crate::app::on_frame`]).
+    /// Finish the current stroke and produce a committed Shape.
     ///
     /// For each tool:
-    /// - **Freehand (≥3 points)**: Runs the full smoothing pipeline. If the pipeline
-    ///   detects a circle, the geometry becomes `Geom::Circle` instead of freehand.
-    /// - **Freehand (<3 points)**: Commits as raw freehand (too few points to smooth).
-    /// - **Line**: Commits a straight line from `start` to the last mouse position.
-    /// - **Rect**: Commits a rectangle from `start` to the last mouse position.
-    /// - **Circle**: Commits a circle centered at `start` with radius = dist(start, end).
+    /// - **Freehand (≥3 points)**: Runs the smoothing pipeline; may snap to circle.
+    /// - **Freehand (<3 points)**: Commits as raw freehand.
+    /// - **Line/Rect/Circle**: Commits the corresponding geometric shape.
     ///
     /// Returns `Some(Shape)` on success, or `None` if the session was already Idle.
     pub(crate) fn finish(self) -> Option<Shape> {
@@ -121,14 +112,11 @@ impl Session {
                         let (smoothed, recognized) = smooth_pipeline(&points);
                         match recognized {
                             RecognizedShape::Circle { center, radius } => {
-                                // The user drew something that looks like a circle —
-                                // snap it to perfect circular geometry.
                                 Geom::Circle { center, radius }
                             }
                             RecognizedShape::Freehand => Geom::Freehand { points: smoothed },
                         }
                     }
-                    // Too few points to run the pipeline — commit as raw freehand.
                     DrawTool::Freehand => Geom::Freehand { points },
                     DrawTool::Line => Geom::Line { start, end },
                     DrawTool::Rect => Geom::Rect { start, end },
@@ -143,7 +131,6 @@ impl Session {
                     geom,
                 })
             }
-            // No active session — nothing to commit.
             Self::Idle => None,
         }
     }

--- a/examples/drawing-pad/src/session.rs
+++ b/examples/drawing-pad/src/session.rs
@@ -1,0 +1,150 @@
+//! # Session state machine
+//!
+//! Tracks the lifecycle of a single drawing stroke from mouse-down to mouse-up.
+//!
+//! States:
+//!   Idle → (mouse press on canvas) → Drawing → (mouse release) → Idle
+//!
+//! During the Drawing state, incoming mouse positions are filtered by adaptive
+//! sampling and accumulated into a point list. On finish, the points are passed
+//! through the smoothing pipeline and committed as a Shape.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::geometry::{dist, Color, Point};
+use crate::shapes::{DrawTool, Geom, Shape};
+use crate::smoothing::{smooth_pipeline, RecognizedShape};
+
+/// The drawing session state machine.
+///
+/// - **Idle** — No active stroke. Waiting for a mouse press on the canvas.
+/// - **Drawing** — An active stroke in progress. Contains:
+///   - `tool` — Which drawing tool is active (Line, Rect, Circle, Freehand).
+///   - `color` — The selected palette color at stroke start.
+///   - `thickness` — The brush size at stroke start.
+///   - `start` — The mouse position where the stroke began (anchor point).
+///   - `points` — Accumulated sample points (for Freehand; geometric tools only use `start`).
+///   - `average_step_distance` — Exponentially-weighted moving average of inter-point
+///     distances, used for adaptive sampling (see `push`).
+pub(crate) enum Session {
+    Idle,
+    Drawing {
+        tool: DrawTool,
+        color: Color,
+        thickness: f32,
+        start: Point,
+        points: Vec<Point>,
+        /// Adaptive sampling threshold: the exponential moving average of the distance
+        /// between consecutive accepted points. Updated each frame with α=0.3.
+        /// New points are only accepted if they exceed 80% of this average (clamped
+        /// to [2.0, 10.0] pixels), reducing noise from slow/stationary mouse input
+        /// while preserving detail in fast strokes.
+        average_step_distance: f32,
+    },
+}
+
+impl Session {
+    /// Begin a new drawing session at the given position. The first point is
+    /// immediately added to the point list. The initial `average_step_distance`
+    /// of 4.0 provides a reasonable starting threshold for the adaptive sampler.
+    pub(crate) fn begin(tool: DrawTool, color: Color, thickness: f32, start: Point) -> Self {
+        Self::Drawing {
+            tool,
+            color,
+            thickness,
+            start,
+            points: vec![start],
+            average_step_distance: 4.0,
+        }
+    }
+
+    /// Accept a new mouse position into the active stroke. Uses adaptive sampling
+    /// to filter out redundant points:
+    ///
+    /// 1. Compute the distance from the new point to the last accepted point.
+    /// 2. Update the running average with exponential moving average (α=0.3):
+    ///    `new_avg = 0.7 × old_avg + 0.3 × distance`
+    ///    This gives recent distances more weight while maintaining stability.
+    /// 3. Accept the point only if distance ≥ 80% of the average (clamped to 2–10px).
+    ///    This threshold adapts to drawing speed:
+    ///    - Fast strokes: average is large → accepts points far apart (captures speed)
+    ///    - Slow strokes: average is small → filters jitter (rejects noise)
+    ///
+    /// The clamp range [2.0, 10.0] prevents the threshold from becoming too tight
+    /// (which would lose detail) or too loose (which would accept jitter).
+    pub(crate) fn push(&mut self, point: Point) {
+        if let Self::Drawing {
+            points,
+            average_step_distance,
+            ..
+        } = self
+        {
+            let distance = points
+                .last()
+                .map_or(f32::INFINITY, |&last| dist(point, last));
+            // Exponential moving average update: blends old average with new sample.
+            *average_step_distance = *average_step_distance * 0.7 + distance * 0.3;
+            // Accept only if the point moves meaningfully relative to recent speed.
+            if distance >= (*average_step_distance * 0.8).clamp(2.0, 10.0) {
+                points.push(point);
+            }
+        }
+    }
+
+    /// Finish the current stroke and produce a committed Shape. Consumes the session
+    /// (moves it out of `App::session` via `mem::replace` in the Input phase of
+    /// [`crate::app::on_frame`]).
+    ///
+    /// For each tool:
+    /// - **Freehand (≥3 points)**: Runs the full smoothing pipeline. If the pipeline
+    ///   detects a circle, the geometry becomes `Geom::Circle` instead of freehand.
+    /// - **Freehand (<3 points)**: Commits as raw freehand (too few points to smooth).
+    /// - **Line**: Commits a straight line from `start` to the last mouse position.
+    /// - **Rect**: Commits a rectangle from `start` to the last mouse position.
+    /// - **Circle**: Commits a circle centered at `start` with radius = dist(start, end).
+    ///
+    /// Returns `Some(Shape)` on success, or `None` if the session was already Idle.
+    pub(crate) fn finish(self) -> Option<Shape> {
+        match self {
+            Self::Drawing {
+                tool,
+                color,
+                thickness,
+                start,
+                points,
+                ..
+            } => {
+                let end = *points.last().unwrap_or(&start);
+                let geom = match tool {
+                    DrawTool::Freehand if points.len() >= 3 => {
+                        let (smoothed, recognized) = smooth_pipeline(&points);
+                        match recognized {
+                            RecognizedShape::Circle { center, radius } => {
+                                // The user drew something that looks like a circle —
+                                // snap it to perfect circular geometry.
+                                Geom::Circle { center, radius }
+                            }
+                            RecognizedShape::Freehand => Geom::Freehand { points: smoothed },
+                        }
+                    }
+                    // Too few points to run the pipeline — commit as raw freehand.
+                    DrawTool::Freehand => Geom::Freehand { points },
+                    DrawTool::Line => Geom::Line { start, end },
+                    DrawTool::Rect => Geom::Rect { start, end },
+                    DrawTool::Circle => Geom::Circle {
+                        center: start,
+                        radius: dist(start, end),
+                    },
+                };
+                Some(Shape {
+                    color,
+                    thickness,
+                    geom,
+                })
+            }
+            // No active session — nothing to commit.
+            Self::Idle => None,
+        }
+    }
+}

--- a/examples/drawing-pad/src/shapes.rs
+++ b/examples/drawing-pad/src/shapes.rs
@@ -36,7 +36,7 @@ impl DrawTool {
         DrawTool::Freehand,
     ];
 
-    /// Human-readable label for the tool, used as the button text in the dock.
+    /// Tool label for the dock button.
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Line => "Line",
@@ -96,7 +96,7 @@ impl Shape {
                 center.1,
                 *radius,
                 0.0,
-                core::f32::consts::TAU, // Full circle: 0 to 2π radians
+                core::f32::consts::TAU,
                 red,
                 green,
                 blue,
@@ -104,8 +104,6 @@ impl Shape {
                 thickness,
             ),
             Geom::Rect { start, end } => {
-                // Normalize corners so left < right and top < bottom,
-                // regardless of which direction the user dragged.
                 let left = start.0.min(end.0);
                 let right = start.0.max(end.0);
                 let top = start.1.min(end.1);

--- a/examples/drawing-pad/src/shapes.rs
+++ b/examples/drawing-pad/src/shapes.rs
@@ -1,0 +1,118 @@
+//! # Drawing tools and committed shapes
+//!
+//! The four available drawing modes (`DrawTool`) and the shape types that hold
+//! committed geometry (`Geom`, `Shape`). A `Shape` is a finalized drawing element
+//! created by `Session::finish()` in [`crate::session`], stored in the app's
+//! `committed_shapes` vector, and re-rendered every frame via [`Shape::render`].
+
+use alloc::vec::Vec;
+
+use oxide_sdk::*;
+
+use crate::geometry::{Color, Point};
+use crate::render::{draw_rect_outline, render_stroke_tube};
+
+/// Available drawing tools.
+///
+/// - **Line** — Click-and-drag from point A to B; commits a straight line segment.
+/// - **Rect** — Click-and-drag defines two opposite corners; commits a rectangle outline.
+/// - **Circle** — Click sets the center; drag sets the radius; commits a circle.
+/// - **Freehand** — Draw freely; the smoothing pipeline processes the stroke, and
+///   circle recognition may promote it to an ideal circle.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DrawTool {
+    Line,
+    Rect,
+    Circle,
+    Freehand,
+}
+
+impl DrawTool {
+    /// All tools in display order (top to bottom in the dock).
+    pub(crate) const ALL: [DrawTool; 4] = [
+        DrawTool::Line,
+        DrawTool::Rect,
+        DrawTool::Circle,
+        DrawTool::Freehand,
+    ];
+
+    /// Human-readable label for the tool, used as the button text in the dock.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Line => "Line",
+            Self::Rect => "Rect",
+            Self::Circle => "Circle",
+            Self::Freehand => "Freehand",
+        }
+    }
+}
+
+/// The geometric definition of a shape. Each variant stores only the minimal data
+/// needed to render that geometry type.
+pub(crate) enum Geom {
+    /// A straight line segment from `start` to `end`.
+    Line { start: Point, end: Point },
+    /// A rectangle defined by two opposite corners (`start` and `end`).
+    /// The actual left/right/top/bottom are computed during rendering by taking
+    /// min/max of the corners, so the user can drag in any direction.
+    Rect { start: Point, end: Point },
+    /// A circle defined by its center point and radius in pixels.
+    Circle { center: Point, radius: f32 },
+    /// A freehand polyline — an ordered list of points that have been smoothed
+    /// and simplified by the smoothing pipeline.
+    Freehand { points: Vec<Point> },
+}
+
+/// A committed drawing element: a geometry definition paired with visual properties.
+/// Shapes are created by `Session::finish()` and stored in `App::committed_shapes`.
+pub(crate) struct Shape {
+    /// The RGB color of this shape.
+    pub(crate) color: Color,
+    /// Stroke thickness in pixels. Used for line width, circle arc thickness, and
+    /// the tube radius for freehand strokes.
+    pub(crate) thickness: f32,
+    /// The geometric definition — determines which rendering path is used.
+    pub(crate) geom: Geom,
+}
+
+impl Shape {
+    /// Render this shape to the canvas by dispatching to the appropriate SDK drawing
+    /// call based on the geometry type.
+    ///
+    /// - **Line** → `canvas_line` with the two endpoints.
+    /// - **Circle** → `canvas_arc` with a full 0→2π arc (full circle).
+    /// - **Rect** → `draw_rect_outline` which renders a filled interior + 4 edge lines.
+    /// - **Freehand** → `render_stroke_tube` which renders connected thick lines with
+    ///   round joints.
+    pub(crate) fn render(&self) {
+        let (red, green, blue) = self.color;
+        let thickness = self.thickness;
+        match &self.geom {
+            Geom::Line { start, end } => canvas_line(
+                start.0, start.1, end.0, end.1, red, green, blue, 255, thickness,
+            ),
+            Geom::Circle { center, radius } => canvas_arc(
+                center.0,
+                center.1,
+                *radius,
+                0.0,
+                core::f32::consts::TAU, // Full circle: 0 to 2π radians
+                red,
+                green,
+                blue,
+                255,
+                thickness,
+            ),
+            Geom::Rect { start, end } => {
+                // Normalize corners so left < right and top < bottom,
+                // regardless of which direction the user dragged.
+                let left = start.0.min(end.0);
+                let right = start.0.max(end.0);
+                let top = start.1.min(end.1);
+                let bottom = start.1.max(end.1);
+                draw_rect_outline(left, top, right, bottom, red, green, blue, thickness);
+            }
+            Geom::Freehand { points } => render_stroke_tube(points, self.color, thickness),
+        }
+    }
+}

--- a/examples/drawing-pad/src/smoothing.rs
+++ b/examples/drawing-pad/src/smoothing.rs
@@ -1,0 +1,444 @@
+//! # Smoothing and shape recognition
+//!
+//! Multi-stage pipeline that transforms raw mouse input into polished, committed
+//! geometry. Raw strokes are noisy (jitter, inconsistent spacing), so we apply
+//! a sequence of filters to produce clean, visually pleasing output.
+//!
+//! The pipeline is applied only to freehand strokes with ≥3 points. Geometric
+//! tools (Line, Rect, Circle) use simple start/end anchors and skip smoothing.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::geometry::Point;
+
+/// The result of shape recognition after smoothing. Determines whether the user's
+/// freehand stroke should be rendered as an ideal geometric shape or kept as a
+/// smoothed polyline.
+pub(crate) enum RecognizedShape {
+    /// The stroke is kept as a freehand polyline (no geometric shape detected).
+    Freehand,
+    /// The stroke closely matches a circle. `center` is the centroid of all points,
+    /// `radius` is the mean distance from center to each point.
+    Circle { center: Point, radius: f32 },
+}
+
+/// The main smoothing pipeline. Takes raw mouse input points and returns a polished
+/// version suitable for rendering, plus the recognized shape (freehand or circle).
+///
+/// Pipeline stages:
+///   1. **Dedup** — Remove consecutive duplicate points (distance² < 0.0001).
+///   2. **Gaussian** — Weighted average blur with σ=1.0 to smooth jitter.
+///   3. **Resample** — Re-space to uniform 3px intervals for consistent processing.
+///   4. **Circle detection** — Multi-test heuristic (closing distance, radius variance).
+///   5. **Ideal arc** — If circle detected, snap each point to the perfect circle.
+///   6. **Douglas-Peucker** — Reduce point count with 2px tolerance.
+///   7. **Chaikin** — Corner-cutting subdivision for final smoothness.
+pub(crate) fn smooth_pipeline(raw_points: &[Point]) -> (Vec<Point>, RecognizedShape) {
+    let deduplicated = remove_consecutive_duplicates(raw_points);
+    let smoothed = gaussian_filter(&deduplicated);
+    let resampled = resample_uniform(&smoothed, 3.0);
+    let recognized = recognize_circle(&resampled);
+    let with_ideal_arc = if let RecognizedShape::Circle { center, radius } = recognized {
+        // If the stroke is a circle, replace each point's position with the ideal
+        // circle point at the same angle — this snaps wobbly hand-drawn circles
+        // to perfect circular geometry.
+        replace_circle_with_ideal_arc(&resampled, center, radius)
+    } else {
+        resampled.clone()
+    };
+    let simplified = simplify_douglas_peucker(&with_ideal_arc, 2.0);
+    (apply_chaikin_smoothing(&simplified), recognized)
+}
+
+/// Remove consecutive duplicate points that are essentially identical (distance² < 0.0001,
+/// i.e. < 0.01px apart). This eliminates redundant samples when the mouse is stationary
+/// or moving extremely slowly, which would otherwise waste processing in downstream stages.
+///
+/// Uses a fold to build the output incrementally, comparing each new point against the
+/// last accepted point.
+fn remove_consecutive_duplicates(points: &[Point]) -> Vec<Point> {
+    points.iter().fold(Vec::new(), |mut acc, &point| {
+        if acc.last().is_none_or(|&(last_x, last_y)| {
+            // Keep the point only if it's more than 0.01px from the last accepted point.
+            // The squared-distance check avoids an expensive sqrt for this tiny threshold.
+            (point.0 - last_x).powi(2) + (point.1 - last_y).powi(2) > 0.0001
+        }) {
+            acc.push(point);
+        }
+        acc
+    })
+}
+
+/// Apply a Gaussian (weighted average) filter to smooth jitter in the point sequence.
+///
+/// Each point is replaced by a Gaussian-weighted average of ALL points in the sequence.
+/// The weight for a neighboring point at index `j` when processing index `i` is:
+///
+///   w(j) = exp(-((i - j)²) / (2σ²))
+///
+/// With σ=1.0, points at the same index get weight 1.0, adjacent indices get ~0.61,
+/// two away get ~0.14, and three+ away are negligible (<0.02). This creates a smooth
+/// blur effect that preserves the overall stroke shape while eliminating high-frequency
+/// jitter.
+///
+/// For sequences shorter than 3 points, returns the input unchanged (not enough context
+/// to meaningfully filter).
+fn gaussian_filter(points: &[Point]) -> Vec<Point> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+    let sigma = 1.0;
+    let sigma_sq = sigma * sigma;
+
+    (0..points.len())
+        .map(|current_idx| {
+            let (weighted_x, weighted_y, weight_sum) = points.iter().enumerate().fold(
+                (0.0, 0.0, 0.0),
+                |(accum_x, accum_y, accum_weight), (neighbor_idx, &(neighbor_x, neighbor_y))| {
+                    // Squared distance between the current index and the neighbor index.
+                    // This is index-space distance (not spatial), so it measures how far
+                    // apart the samples are in the sequence, not on the canvas.
+                    let dist_sq = ((current_idx as i32 - neighbor_idx as i32).pow(2)) as f32;
+                    // Gaussian kernel: high weight for nearby indices, rapid falloff for distant ones.
+                    let weight = (-dist_sq / (2.0 * sigma_sq)).exp();
+                    (
+                        accum_x + neighbor_x * weight,
+                        accum_y + neighbor_y * weight,
+                        accum_weight + weight,
+                    )
+                },
+            );
+            // Normalize by total weight to get the weighted average position.
+            (weighted_x / weight_sum, weighted_y / weight_sum)
+        })
+        .collect()
+}
+
+/// Compute the total arc length of a polyline by summing the Euclidean distances
+/// between each consecutive pair of points. Uses `windows(2)` to iterate over
+/// adjacent pairs.
+///
+/// This is used by `resample_uniform` to determine how many output points are needed
+/// and by `path_length` to space them evenly.
+fn path_length(points: &[Point]) -> f32 {
+    points
+        .windows(2)
+        .map(|w| ((w[1].0 - w[0].0).powi(2) + (w[1].1 - w[0].1).powi(2)).sqrt())
+        .sum()
+}
+
+/// Re-space the point sequence so that consecutive points are approximately
+/// `target_spacing` pixels apart (uniform spacing along the path).
+///
+/// This is important because raw mouse input has inconsistent spacing: fast strokes
+/// produce sparse points while slow strokes produce dense clusters. Uniform resampling
+/// ensures downstream algorithms (Douglas-Peucker, circle detection) work consistently
+/// regardless of drawing speed.
+///
+/// Algorithm:
+///   1. Compute total path length.
+///   2. Determine output count = ceil(total_length / target_spacing).
+///   3. Walk the source polyline, inserting interpolated points at each target distance.
+///   4. Linearly interpolate between the two enclosing source points at each insertion.
+///   5. Always include the original last point (prevents truncation).
+fn resample_uniform(points: &[Point], target_spacing: f32) -> Vec<Point> {
+    if points.len() < 2 {
+        return points.to_vec();
+    }
+    let total_length = path_length(points);
+    if total_length <= target_spacing {
+        return points.to_vec();
+    }
+    let output_count = (total_length / target_spacing).ceil() as usize;
+    let mut output = Vec::with_capacity(output_count + 1);
+    output.push(points[0]);
+    let mut accumulated_distance = 0.0;
+    let mut source_index = 0;
+    for output_index in 1..=output_count {
+        let target_distance = output_index as f32 * target_spacing;
+        // Walk source segments until we've covered enough distance to place the next
+        // output point.
+        while source_index < points.len() - 1 {
+            let seg_start = points[source_index];
+            let seg_end = points[source_index + 1];
+            let seg_len =
+                ((seg_end.0 - seg_start.0).powi(2) + (seg_end.1 - seg_start.1).powi(2)).sqrt();
+            if accumulated_distance + seg_len >= target_distance {
+                // Interpolate: t is the fractional position along this segment (0.0–1.0)
+                // where the output point should land.
+                let t = (target_distance - accumulated_distance) / seg_len;
+                output.push((
+                    seg_start.0 + (seg_end.0 - seg_start.0) * t,
+                    seg_start.1 + (seg_end.1 - seg_start.1) * t,
+                ));
+                break;
+            }
+            accumulated_distance += seg_len;
+            source_index += 1;
+        }
+    }
+    // Always include the original last point to prevent the polyline from being
+    // truncated by floating-point rounding in the loop above.
+    if let Some(&last_point) = points.last() {
+        if output.last().is_none_or(|&(lx, ly)| {
+            (last_point.0 - lx).powi(2) + (last_point.1 - ly).powi(2) > 0.01
+        }) {
+            output.push(last_point);
+        }
+    }
+    output
+}
+
+/// Douglas-Peucker line simplification algorithm. Reduces the number of points in a
+/// polyline while preserving its overall shape within a given `tolerance` threshold.
+///
+/// Algorithm:
+///   1. Start with the line between the first and last points.
+///   2. Find the point farthest from this line (perpendicular distance).
+///   3. If the farthest distance exceeds `tolerance`, keep that point and recurse on
+///      both halves (start→farthest, farthest→end).
+///   4. If no point exceeds tolerance, discard all intermediate points (the line segment
+///      is a good enough approximation).
+///
+/// The result is a polyline that uses the minimum number of points to stay within
+/// `tolerance` of the original shape. A tolerance of 2.0px means the simplified path
+/// deviates at most 2 pixels from the original.
+fn simplify_douglas_peucker(points: &[Point], tolerance: f32) -> Vec<Point> {
+    if points.len() <= 2 {
+        return points.to_vec();
+    }
+    // Boolean flags: which points to keep in the output.
+    let mut keep_flags = vec![false; points.len()];
+    keep_flags[0] = true;
+    keep_flags[points.len() - 1] = true;
+    dp_recurse(points, 0, points.len() - 1, tolerance, &mut keep_flags);
+    points
+        .iter()
+        .zip(keep_flags)
+        .filter(|(_, k)| *k)
+        .map(|(p, _)| *p)
+        .collect()
+}
+
+/// Recursive helper for Douglas-Peucker simplification. Finds the farthest point
+/// from the line segment between `points[start_index]` and `points[end_index]`,
+/// and recurses if it exceeds the tolerance.
+///
+/// Distance calculation uses point-to-line-segment projection:
+///   1. Project the point onto the line defined by start→end.
+///   2. Clamp the projection parameter `t` to [0, 1] to stay within the segment.
+///   3. Compute the distance from the point to its projection on the segment.
+///
+/// If the segment is degenerate (zero length), falls back to simple point-to-start distance.
+fn dp_recurse(
+    points: &[Point],
+    start_index: usize,
+    end_index: usize,
+    tolerance: f32,
+    keep_flags: &mut [bool],
+) {
+    if end_index <= start_index + 1 {
+        return;
+    }
+    let (start_x, start_y) = points[start_index];
+    let (end_x, end_y) = points[end_index];
+    // Direction vector of the segment, and its squared length.
+    let (segment_dx, segment_dy) = (end_x - start_x, end_y - start_y);
+    let seg_sq = segment_dx * segment_dx + segment_dy * segment_dy;
+
+    // Find the point with maximum perpendicular distance to the segment.
+    let farthest = (start_index + 1..end_index)
+        .map(|point_idx| {
+            let (point_x, point_y) = points[point_idx];
+            let distance = if seg_sq <= f32::EPSILON {
+                // Degenerate segment (start == end): distance is just point-to-point.
+                ((point_x - start_x).powi(2) + (point_y - start_y).powi(2)).sqrt()
+            } else {
+                // Project the point onto the segment line. `t` is the fractional position
+                // along the segment (0.0 = at start, 1.0 = at end). Clamped to [0, 1]
+                // so the projection stays within the segment bounds.
+                let t = (((point_x - start_x) * segment_dx + (point_y - start_y) * segment_dy)
+                    / seg_sq)
+                    .clamp(0.0, 1.0);
+                // Perpendicular distance from the point to its projection on the segment.
+                ((point_x - start_x - t * segment_dx).powi(2)
+                    + (point_y - start_y - t * segment_dy).powi(2))
+                .sqrt()
+            };
+            (distance, point_idx)
+        })
+        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(core::cmp::Ordering::Equal));
+
+    if let Some((dist, farthest_index)) = farthest {
+        if dist > tolerance {
+            // The farthest point is outside tolerance — keep it and recurse on both halves.
+            keep_flags[farthest_index] = true;
+            dp_recurse(points, start_index, farthest_index, tolerance, keep_flags);
+            dp_recurse(points, farthest_index, end_index, tolerance, keep_flags);
+        }
+        // If dist <= tolerance, all intermediate points can be discarded — the straight
+        // line from start to end is a good enough approximation.
+    }
+}
+
+/// Replace a recognized circle's points with ideal circular geometry. For each input
+/// point, compute its angle from the circle's center, then place the output point on
+/// the ideal circle at that angle.
+///
+/// This transforms a wobbly hand-drawn circle into a perfect geometric circle while
+/// preserving the angular ordering and extent of the original stroke (i.e., if the user
+/// drew a 270° arc, the output is a 270° arc on the ideal circle, not a full circle).
+///
+/// Requires at least 8 points to operate; returns the input unchanged for shorter strokes.
+fn replace_circle_with_ideal_arc(points: &[Point], center: Point, radius: f32) -> Vec<Point> {
+    if points.len() < 8 {
+        return points.to_vec();
+    }
+
+    let mut arc_points = Vec::with_capacity(points.len());
+    for point in points {
+        // Compute the angle of this point relative to the circle center using atan2.
+        // atan2 returns the angle in radians from the +X axis, ranging from -π to +π.
+        let angle = (point.1 - center.1).atan2(point.0 - center.0);
+        // Place the point on the ideal circle at this angle.
+        arc_points.push((
+            center.0 + radius * angle.cos(),
+            center.1 + radius * angle.sin(),
+        ));
+    }
+    arc_points
+}
+
+/// Attempt to recognize whether the given polyline approximates a circle.
+///
+/// Uses four heuristic tests, applied as early-exit gates:
+///
+///   1. **Closing distance** — The distance between the first and last points must be
+///      less than 25% of the bounding box diagonal. A circle should roughly close on
+///      itself; an open stroke (like a spiral or arc) fails this check.
+///
+///   2. **Minimum radius** — The mean radius must be > 5px. Very small "circles" are
+///      just jitter and should be treated as freehand.
+///
+///   3. **Coefficient of variation** — The standard deviation of radii divided by the
+///      mean radius must be < 8%. A perfect circle has all radii equal (CV = 0);
+///      real hand-drawn circles have slight variation.
+///
+///   4. **Maximum deviation** — No single point's radius can differ from the mean by
+///      more than 12%. This catches strokes that are mostly circular but have one
+///      outlier section (like a circle with a tail).
+///
+/// If all tests pass, returns `RecognizedShape::Circle` with the computed center and
+/// mean radius. Otherwise returns `RecognizedShape::Freehand`.
+fn recognize_circle(points: &[Point]) -> RecognizedShape {
+    if points.len() < 8 {
+        return RecognizedShape::Freehand;
+    }
+    // Test 1: Closing distance — how close is the end point to the start point?
+    let (first_point, last_point) = (points[0], *points.last().unwrap());
+    let closing_distance =
+        ((last_point.0 - first_point.0).powi(2) + (last_point.1 - first_point.1).powi(2)).sqrt();
+
+    // Compute the bounding box of all points to get a scale reference.
+    let (min_x, max_x) = points
+        .iter()
+        .fold((f32::MAX, f32::MIN), |(curr_min, curr_max), point| {
+            (curr_min.min(point.0), curr_max.max(point.0))
+        });
+    let (min_y, max_y) = points
+        .iter()
+        .fold((f32::MAX, f32::MIN), |(curr_min, curr_max), point| {
+            (curr_min.min(point.1), curr_max.max(point.1))
+        });
+    let bbox_diag = ((max_x - min_x).powi(2) + (max_y - min_y).powi(2)).sqrt();
+    if closing_distance > bbox_diag * 0.25 {
+        // The stroke doesn't close on itself — not a circle.
+        return RecognizedShape::Freehand;
+    }
+
+    // Compute the centroid (arithmetic mean of all points) as the candidate center.
+    let point_count = points.len() as f32;
+    let center_x = points.iter().map(|point| point.0).sum::<f32>() / point_count;
+    let center_y = points.iter().map(|point| point.1).sum::<f32>() / point_count;
+
+    // Compute the radius of each point from the centroid.
+    let radii: Vec<f32> = points
+        .iter()
+        .map(|point| ((point.0 - center_x).powi(2) + (point.1 - center_y).powi(2)).sqrt())
+        .collect();
+    let mean_radius = radii.iter().sum::<f32>() / point_count;
+
+    // Test 2: Minimum radius — too small to be a meaningful circle.
+    if mean_radius < 5.0 {
+        return RecognizedShape::Freehand;
+    }
+
+    // Test 3: Coefficient of variation (stddev / mean) — measures how consistent
+    // the radii are. A perfect circle has CV = 0; real circles typically have CV < 0.08.
+    let stddev = (radii
+        .iter()
+        .map(|radius_val| (radius_val - mean_radius).powi(2))
+        .sum::<f32>()
+        / point_count)
+        .sqrt();
+    if stddev / mean_radius > 0.08 {
+        return RecognizedShape::Freehand;
+    }
+
+    // Test 4: Maximum single-point deviation — catches outlier points that the
+    // stddev test might miss (e.g., one bad point in a long stroke).
+    let max_deviation = radii
+        .iter()
+        .map(|radius_val| (radius_val - mean_radius).abs())
+        .fold(0.0f32, f32::max);
+    if max_deviation > mean_radius * 0.12 {
+        return RecognizedShape::Freehand;
+    }
+
+    RecognizedShape::Circle {
+        center: (center_x, center_y),
+        radius: mean_radius,
+    }
+}
+
+/// Apply Chaikin's corner-cutting algorithm for one iteration of curve subdivision.
+///
+/// For each pair of consecutive points (A, B), two new points are generated:
+///   - P₁ = 0.75·A + 0.25·B  (quarter-point, closer to A)
+///   - P₂ = 0.25·A + 0.75·B  (three-quarter point, closer to B)
+///
+/// The original points A and B are removed (except the first and last endpoints,
+/// which are preserved). This effectively "cuts" every sharp corner, producing a
+/// smoother curve that approximates the original polyline.
+///
+/// One iteration approximately doubles the point count. The visual effect is a
+/// gentle rounding of corners — ideal for the final pass after Douglas-Peucker
+/// simplification, which can leave sharp angles.
+///
+/// Example: A polyline with points [P0, P1, P2, P3] becomes:
+///   [P0, ¾P0+¼P1, ¼P0+¾P1, ¾P1+¼P2, ¼P1+¾P2, ¾P2+¼P3, ¼P2+¾P3, P3]
+fn apply_chaikin_smoothing(points: &[Point]) -> Vec<Point> {
+    if points.len() < 3 {
+        return points.to_vec();
+    }
+    // Start with the first endpoint (preserved).
+    let mut result = vec![points[0]];
+    // For each edge, emit the two Chaikin subdivision points.
+    result.extend(points.windows(2).flat_map(|window| {
+        let (point_a, point_b) = (window[0], window[1]);
+        [
+            (
+                point_a.0 * 0.75 + point_b.0 * 0.25,
+                point_a.1 * 0.75 + point_b.1 * 0.25,
+            ),
+            (
+                point_a.0 * 0.25 + point_b.0 * 0.75,
+                point_a.1 * 0.25 + point_b.1 * 0.75,
+            ),
+        ]
+    }));
+    // End with the last endpoint (preserved).
+    result.push(*points.last().unwrap());
+    result
+}

--- a/examples/drawing-pad/src/smoothing.rs
+++ b/examples/drawing-pad/src/smoothing.rs
@@ -40,9 +40,6 @@ pub(crate) fn smooth_pipeline(raw_points: &[Point]) -> (Vec<Point>, RecognizedSh
     let resampled = resample_uniform(&smoothed, 3.0);
     let recognized = recognize_circle(&resampled);
     let with_ideal_arc = if let RecognizedShape::Circle { center, radius } = recognized {
-        // If the stroke is a circle, replace each point's position with the ideal
-        // circle point at the same angle — this snaps wobbly hand-drawn circles
-        // to perfect circular geometry.
         replace_circle_with_ideal_arc(&resampled, center, radius)
     } else {
         resampled.clone()
@@ -60,8 +57,6 @@ pub(crate) fn smooth_pipeline(raw_points: &[Point]) -> (Vec<Point>, RecognizedSh
 fn remove_consecutive_duplicates(points: &[Point]) -> Vec<Point> {
     points.iter().fold(Vec::new(), |mut acc, &point| {
         if acc.last().is_none_or(|&(last_x, last_y)| {
-            // Keep the point only if it's more than 0.01px from the last accepted point.
-            // The squared-distance check avoids an expensive sqrt for this tiny threshold.
             (point.0 - last_x).powi(2) + (point.1 - last_y).powi(2) > 0.0001
         }) {
             acc.push(point);
@@ -96,11 +91,7 @@ fn gaussian_filter(points: &[Point]) -> Vec<Point> {
             let (weighted_x, weighted_y, weight_sum) = points.iter().enumerate().fold(
                 (0.0, 0.0, 0.0),
                 |(accum_x, accum_y, accum_weight), (neighbor_idx, &(neighbor_x, neighbor_y))| {
-                    // Squared distance between the current index and the neighbor index.
-                    // This is index-space distance (not spatial), so it measures how far
-                    // apart the samples are in the sequence, not on the canvas.
                     let dist_sq = ((current_idx as i32 - neighbor_idx as i32).pow(2)) as f32;
-                    // Gaussian kernel: high weight for nearby indices, rapid falloff for distant ones.
                     let weight = (-dist_sq / (2.0 * sigma_sq)).exp();
                     (
                         accum_x + neighbor_x * weight,
@@ -109,7 +100,6 @@ fn gaussian_filter(points: &[Point]) -> Vec<Point> {
                     )
                 },
             );
-            // Normalize by total weight to get the weighted average position.
             (weighted_x / weight_sum, weighted_y / weight_sum)
         })
         .collect()
@@ -157,16 +147,12 @@ fn resample_uniform(points: &[Point], target_spacing: f32) -> Vec<Point> {
     let mut source_index = 0;
     for output_index in 1..=output_count {
         let target_distance = output_index as f32 * target_spacing;
-        // Walk source segments until we've covered enough distance to place the next
-        // output point.
         while source_index < points.len() - 1 {
             let seg_start = points[source_index];
             let seg_end = points[source_index + 1];
             let seg_len =
                 ((seg_end.0 - seg_start.0).powi(2) + (seg_end.1 - seg_start.1).powi(2)).sqrt();
             if accumulated_distance + seg_len >= target_distance {
-                // Interpolate: t is the fractional position along this segment (0.0–1.0)
-                // where the output point should land.
                 let t = (target_distance - accumulated_distance) / seg_len;
                 output.push((
                     seg_start.0 + (seg_end.0 - seg_start.0) * t,
@@ -178,8 +164,7 @@ fn resample_uniform(points: &[Point], target_spacing: f32) -> Vec<Point> {
             source_index += 1;
         }
     }
-    // Always include the original last point to prevent the polyline from being
-    // truncated by floating-point rounding in the loop above.
+    // Always include the original last point to prevent truncation from rounding.
     if let Some(&last_point) = points.last() {
         if output.last().is_none_or(|&(lx, ly)| {
             (last_point.0 - lx).powi(2) + (last_point.1 - ly).powi(2) > 0.01
@@ -243,7 +228,6 @@ fn dp_recurse(
     }
     let (start_x, start_y) = points[start_index];
     let (end_x, end_y) = points[end_index];
-    // Direction vector of the segment, and its squared length.
     let (segment_dx, segment_dy) = (end_x - start_x, end_y - start_y);
     let seg_sq = segment_dx * segment_dx + segment_dy * segment_dy;
 
@@ -252,16 +236,11 @@ fn dp_recurse(
         .map(|point_idx| {
             let (point_x, point_y) = points[point_idx];
             let distance = if seg_sq <= f32::EPSILON {
-                // Degenerate segment (start == end): distance is just point-to-point.
                 ((point_x - start_x).powi(2) + (point_y - start_y).powi(2)).sqrt()
             } else {
-                // Project the point onto the segment line. `t` is the fractional position
-                // along the segment (0.0 = at start, 1.0 = at end). Clamped to [0, 1]
-                // so the projection stays within the segment bounds.
                 let t = (((point_x - start_x) * segment_dx + (point_y - start_y) * segment_dy)
                     / seg_sq)
                     .clamp(0.0, 1.0);
-                // Perpendicular distance from the point to its projection on the segment.
                 ((point_x - start_x - t * segment_dx).powi(2)
                     + (point_y - start_y - t * segment_dy).powi(2))
                 .sqrt()
@@ -272,13 +251,10 @@ fn dp_recurse(
 
     if let Some((dist, farthest_index)) = farthest {
         if dist > tolerance {
-            // The farthest point is outside tolerance — keep it and recurse on both halves.
             keep_flags[farthest_index] = true;
             dp_recurse(points, start_index, farthest_index, tolerance, keep_flags);
             dp_recurse(points, farthest_index, end_index, tolerance, keep_flags);
         }
-        // If dist <= tolerance, all intermediate points can be discarded — the straight
-        // line from start to end is a good enough approximation.
     }
 }
 
@@ -298,10 +274,7 @@ fn replace_circle_with_ideal_arc(points: &[Point], center: Point, radius: f32) -
 
     let mut arc_points = Vec::with_capacity(points.len());
     for point in points {
-        // Compute the angle of this point relative to the circle center using atan2.
-        // atan2 returns the angle in radians from the +X axis, ranging from -π to +π.
         let angle = (point.1 - center.1).atan2(point.0 - center.0);
-        // Place the point on the ideal circle at this angle.
         arc_points.push((
             center.0 + radius * angle.cos(),
             center.1 + radius * angle.sin(),
@@ -335,12 +308,11 @@ fn recognize_circle(points: &[Point]) -> RecognizedShape {
     if points.len() < 8 {
         return RecognizedShape::Freehand;
     }
-    // Test 1: Closing distance — how close is the end point to the start point?
+    // Test 1: Closing distance.
     let (first_point, last_point) = (points[0], *points.last().unwrap());
     let closing_distance =
         ((last_point.0 - first_point.0).powi(2) + (last_point.1 - first_point.1).powi(2)).sqrt();
 
-    // Compute the bounding box of all points to get a scale reference.
     let (min_x, max_x) = points
         .iter()
         .fold((f32::MAX, f32::MIN), |(curr_min, curr_max), point| {
@@ -353,23 +325,19 @@ fn recognize_circle(points: &[Point]) -> RecognizedShape {
         });
     let bbox_diag = ((max_x - min_x).powi(2) + (max_y - min_y).powi(2)).sqrt();
     if closing_distance > bbox_diag * 0.25 {
-        // The stroke doesn't close on itself — not a circle.
         return RecognizedShape::Freehand;
     }
 
-    // Compute the centroid (arithmetic mean of all points) as the candidate center.
     let point_count = points.len() as f32;
     let center_x = points.iter().map(|point| point.0).sum::<f32>() / point_count;
     let center_y = points.iter().map(|point| point.1).sum::<f32>() / point_count;
 
-    // Compute the radius of each point from the centroid.
     let radii: Vec<f32> = points
         .iter()
         .map(|point| ((point.0 - center_x).powi(2) + (point.1 - center_y).powi(2)).sqrt())
         .collect();
     let mean_radius = radii.iter().sum::<f32>() / point_count;
 
-    // Test 2: Minimum radius — too small to be a meaningful circle.
     if mean_radius < 5.0 {
         return RecognizedShape::Freehand;
     }
@@ -386,8 +354,6 @@ fn recognize_circle(points: &[Point]) -> RecognizedShape {
         return RecognizedShape::Freehand;
     }
 
-    // Test 4: Maximum single-point deviation — catches outlier points that the
-    // stddev test might miss (e.g., one bad point in a long stroke).
     let max_deviation = radii
         .iter()
         .map(|radius_val| (radius_val - mean_radius).abs())
@@ -422,9 +388,7 @@ fn apply_chaikin_smoothing(points: &[Point]) -> Vec<Point> {
     if points.len() < 3 {
         return points.to_vec();
     }
-    // Start with the first endpoint (preserved).
     let mut result = vec![points[0]];
-    // For each edge, emit the two Chaikin subdivision points.
     result.extend(points.windows(2).flat_map(|window| {
         let (point_a, point_b) = (window[0], window[1]);
         [
@@ -438,7 +402,6 @@ fn apply_chaikin_smoothing(points: &[Point]) -> Vec<Point> {
             ),
         ]
     }));
-    // End with the last endpoint (preserved).
     result.push(*points.last().unwrap());
     result
 }

--- a/examples/index/src/lib.rs
+++ b/examples/index/src/lib.rs
@@ -15,6 +15,7 @@ const PURPLE: (u8, u8, u8) = (160, 90, 220);
 const PINK: (u8, u8, u8) = (240, 140, 200);
 const CYAN: (u8, u8, u8) = (80, 220, 220);
 const YELLOW: (u8, u8, u8) = (240, 220, 80);
+const RED: (u8, u8, u8) = (239, 68, 68);
 const DIVIDER: (u8, u8, u8) = (50, 45, 70);
 
 struct Card {
@@ -83,6 +84,14 @@ const CARDS: &[Card] = &[
         url: "https://oxide.foundation/file_picker_demo.wasm",
         color: YELLOW,
         icon_char: "F",
+    },
+    Card {
+        title: "Drawing Pad",
+        subtitle: "drawing_pad.wasm",
+        description: "Freehand strokes with circle recognition, shapes, brush size, and palette.",
+        url: "https://oxide.foundation/drawing_pad.wasm",
+        color: RED,
+        icon_char: "D",
     },
 ];
 


### PR DESCRIPTION
Closes #22

## What

Add `drawing-pad` — an interactive drawing application that runs as a WASM
guest in the Oxide browser. It is a real, usable tool (not a minimal
placeholder), featuring freehand drawing with automatic circle recognition,
a multi-stage stroke-smoothing pipeline, four drawing tools, a color
palette, adjustable brush size, and a dock UI.

## Why

The current examples lean toward simple single-file apps (`hello-oxide`,
`timer-demo`). This example demonstrates that Oxide can host genuinely
interactive applications with algorithmic depth — smoothing, shape
recognition, state machines — and it does so with a **multi-file module
structure** rather than stuffing everything into one `lib.rs`.

That structure is intentional: it shows new contributors how to organise
a non-trivial Oxide guest app, and it makes each concern (geometry,
algorithms, UI, state) independently readable and maintainable. A single
1300-line file would be harder to navigate and less useful as a reference.

## Files

| File | Role |
|------|------|
| `examples/drawing-pad/src/lib.rs` | Crate root — module declarations + crate doc |
| `examples/drawing-pad/src/geometry.rs` | Core types (`Point`, `Color`), palette, layout constants |
| `examples/drawing-pad/src/smoothing.rs` | Stroke pipeline: Gaussian, resample, Douglas-Peucker, Chaikin, circle recognition |
| `examples/drawing-pad/src/shapes.rs` | `DrawTool`, `Geom`, `Shape` — committed geometry + rendering dispatch |
| `examples/drawing-pad/src/session.rs` | Drawing-session state machine with adaptive point sampling |
| `examples/drawing-pad/src/render.rs` | Low-level canvas helpers (rect outlines, stroke tubes, live preview) |
| `examples/drawing-pad/src/app.rs` | `App` singleton, `start_app`/`on_frame` WASM exports, dock UI layout |
| `examples/drawing-pad/Cargo.toml` | cdylib crate with `oxide-sdk` dependency |
| `Cargo.toml` | Workspace member added |
| `examples/index/src/lib.rs` | New "Drawing Pad" card in the demo hub |

## Testing

- `cargo fmt --all --check` — clean
- `cargo clippy -p drawing-pad -p index --all-targets -- -D warnings` — clean
- `cargo test --workspace` — passes
- `cargo build --target wasm32-unknown-unknown --release -p drawing-pad` — builds
- `drawing_pad.wasm` produced (78 KB)

> **Note:** Full-workspace `clippy --all-targets -- -D warnings` has two
> pre-existing failures in `oxide-browser` (`subtitle.rs:13` question-mark
> lint, `ui.rs:669` as-chunks lint). These are untouched by this PR — no
> oxide-browser files are changed (confirmed via `git diff -- oxide-browser`).

## In-browser verification

Run `cargo run -p oxide-browser`, load `drawing_pad.wasm`, and confirm:
1. Freehand drawing works with smooth output
2. Drawing a circle is auto-recognized and snapped to ideal geometry
3. Line / Rect / Circle tools produce correct shapes
4. Brush size slider adjusts stroke width in real time
5. Color palette switches the active drawing color
6. Clear button (✕) resets the canvas